### PR TITLE
feat(web): download artifacts as CSV + stabilize run details UX

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,13 @@ To run a single package:
 - Connector secrets must be provided via env vars at deploy time (example: `JOSHUA_PROJECT_API_KEY`).
 
 ## Deploy Flow (Mandatory)
+- For every code change session, complete this sequence before handoff:
+  - Run relevant tests/checks for touched packages.
+  - Commit code to a feature branch and open a PR.
+  - Merge PR to `main`.
+  - Return local repo to `main`.
+  - Clean up merged branches (local + remote).
+  - Redeploy Firebase App Hosting.
 - After every merged PR, immediately redeploy the web app on Firebase App Hosting.
 - Command:
   - `firebase apphosting:rollouts:create accelerate-core --project accelerate-global-473318 --git-branch main --force`

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -18,6 +18,7 @@ Must not live here:
 - Build: `pnpm --filter @accelerate-core/web run build`
 - Typecheck: `pnpm --filter @accelerate-core/web run typecheck`
 - Lint: `pnpm --filter @accelerate-core/web run lint`
+- Test: `pnpm --filter @accelerate-core/web run test`
 
 Runtime config:
 - Firebase client config is provided via `NEXT_PUBLIC_FIREBASE_*`.
@@ -38,7 +39,7 @@ Runtime config:
 - `apps/web/src/app/api/runs/[runId]/route.ts` (proxy to API `/runs/:id`)
 - `apps/web/src/app/api/runs/[runId]/cancel/route.ts` (proxy to API `/runs/:id/cancel`)
 - `apps/web/src/app/api/runs/[runId]/logs/route.ts` (proxy to API `/runs/:id/logs`)
-- `apps/web/src/app/api/runs/[runId]/raw/route.ts` (proxy to API `/runs/:id/raw`)
+- `apps/web/src/app/api/runs/[runId]/raw/route.ts` (converts API NDJSON artifact stream to CSV download)
 - `apps/web/src/lib/firebase/client.ts` (Firebase client placeholder)
 - `apps/web/src/lib/auth/AuthProvider.tsx` (Auth wiring placeholder)
 - `apps/web/src/lib/auth/AuthControls.tsx` (Google sign-in/out UI)
@@ -59,7 +60,7 @@ API proxy routes (server-side):
 - `/api/runs/[runId]` forwards to `${API_BASE_URL || NEXT_PUBLIC_API_BASE_URL}/runs/:id`
 - `/api/runs/[runId]/cancel` forwards to `${API_BASE_URL || NEXT_PUBLIC_API_BASE_URL}/runs/:id/cancel`
 - `/api/runs/[runId]/logs` forwards to `${API_BASE_URL || NEXT_PUBLIC_API_BASE_URL}/runs/:id/logs` (returns `{ logs }`)
-- `/api/runs/[runId]/raw` forwards to `${API_BASE_URL || NEXT_PUBLIC_API_BASE_URL}/runs/:id/raw` (streams NDJSON download)
+- `/api/runs/[runId]/raw` fetches `${API_BASE_URL || NEXT_PUBLIC_API_BASE_URL}/runs/:id/raw`, converts NDJSON to CSV, and streams `text/csv` download
 - Requests forward `Authorization: Bearer <Firebase ID token>` from the browser to the API.
 
 Admin allowlist (V1 internal-only):

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,10 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "build": "next build",
+    "build": "pnpm --filter @accelerate-core/shared build && next build",
     "dev": "next dev -p 3000",
     "lint": "eslint .",
-    "test": "node -e \"console.log('apps/web: no tests yet')\"",
+    "test": "node --test test/**/*.test.ts",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "start": "next start -p 3000"
   },

--- a/apps/web/src/app/api/runs/[runId]/raw/download-csv.ts
+++ b/apps/web/src/app/api/runs/[runId]/raw/download-csv.ts
@@ -1,0 +1,84 @@
+import { collectCsvColumnsFromNdjson, createCsvStreamFromNdjson } from "./ndjson-to-csv.ts";
+
+function buildErrorResponse(status: number, fallbackMessage: string, textBody: string): Response {
+  try {
+    const parsed = JSON.parse(textBody) as unknown;
+    return Response.json(parsed ?? { error: fallbackMessage }, { status });
+  } catch {
+    return Response.json({ error: textBody || fallbackMessage }, { status });
+  }
+}
+
+export function csvFilenameFromContentDisposition(contentDisposition: string | null, runId: string): string {
+  const fallback = `run-${runId}.csv`;
+  if (!contentDisposition) return fallback;
+
+  const match = /filename\*?=(?:UTF-8''|")?([^\";]+)"?/i.exec(contentDisposition);
+  if (!match) return fallback;
+
+  let parsed = match[1] ?? fallback;
+  try {
+    parsed = decodeURIComponent(parsed);
+  } catch {
+    // keep raw value
+  }
+
+  const basename = parsed.split(/[\\/]/).pop() ?? parsed;
+  const replaced = basename.replace(/(?:\.bq)?\.ndjson$/i, ".csv").replace(/\.jsonl$/i, ".csv");
+  return replaced.toLowerCase().endsWith(".csv") ? replaced : `${replaced}.csv`;
+}
+
+export async function buildCsvDownloadResponse(input: {
+  runId: string;
+  auth: string;
+  apiBaseUrl: string;
+  fetchImpl?: typeof fetch;
+}): Promise<Response> {
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const rawUrl = `${input.apiBaseUrl}/runs/${encodeURIComponent(input.runId)}/raw`;
+
+  const columnsResponse = await fetchImpl(rawUrl, {
+    method: "GET",
+    headers: {
+      authorization: input.auth
+    }
+  });
+  if (!columnsResponse.ok) {
+    return buildErrorResponse(columnsResponse.status, `Request failed: ${columnsResponse.status}`, await columnsResponse.text());
+  }
+  if (!columnsResponse.body) {
+    return Response.json({ error: "Raw artifact stream unavailable" }, { status: 502 });
+  }
+
+  let columns: string[];
+  try {
+    columns = await collectCsvColumnsFromNdjson(columnsResponse.body);
+  } catch {
+    return Response.json({ error: "Failed to parse raw artifact" }, { status: 500 });
+  }
+
+  const csvResponse = await fetchImpl(rawUrl, {
+    method: "GET",
+    headers: {
+      authorization: input.auth
+    }
+  });
+  if (!csvResponse.ok) {
+    return buildErrorResponse(csvResponse.status, `Request failed: ${csvResponse.status}`, await csvResponse.text());
+  }
+  if (!csvResponse.body) {
+    return Response.json({ error: "Raw artifact stream unavailable" }, { status: 502 });
+  }
+
+  const headers = new Headers();
+  headers.set("content-type", "text/csv; charset=utf-8");
+  headers.set(
+    "content-disposition",
+    `attachment; filename="${csvFilenameFromContentDisposition(csvResponse.headers.get("content-disposition"), input.runId)}"`
+  );
+
+  return new Response(createCsvStreamFromNdjson(csvResponse.body, columns), {
+    status: 200,
+    headers
+  });
+}

--- a/apps/web/src/app/api/runs/[runId]/raw/ndjson-to-csv.ts
+++ b/apps/web/src/app/api/runs/[runId]/raw/ndjson-to-csv.ts
@@ -1,0 +1,131 @@
+const CSV_BOM = "\uFEFF";
+
+type JsonRecord = Record<string, unknown>;
+
+function normalizeRecord(value: unknown): JsonRecord {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as JsonRecord;
+  }
+  return { value };
+}
+
+async function forEachNdjsonRecord(
+  stream: ReadableStream<Uint8Array>,
+  onRecord: (value: unknown) => Promise<void> | void
+): Promise<void> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let lineNumber = 0;
+
+  const processLine = async (lineRaw: string) => {
+    lineNumber += 1;
+    const line = lineRaw.trim();
+    if (!line) return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      throw new Error(`Invalid NDJSON payload at line ${lineNumber}`);
+    }
+    await onRecord(parsed);
+  };
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      let newlineIdx = buffer.indexOf("\n");
+      while (newlineIdx >= 0) {
+        const line = buffer.slice(0, newlineIdx).replace(/\r$/, "");
+        buffer = buffer.slice(newlineIdx + 1);
+        await processLine(line);
+        newlineIdx = buffer.indexOf("\n");
+      }
+    }
+
+    buffer += decoder.decode();
+    if (buffer.length > 0) {
+      await processLine(buffer.replace(/\r$/, ""));
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function stringifyScalar(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") return String(value);
+  return JSON.stringify(value);
+}
+
+function escapeCsvCell(value: string): string {
+  const escaped = value.replaceAll("\"", "\"\"");
+  if (/[",\n\r]/.test(value)) return `"${escaped}"`;
+  return escaped;
+}
+
+export async function collectCsvColumnsFromNdjson(stream: ReadableStream<Uint8Array>): Promise<string[]> {
+  const keys = new Set<string>();
+
+  await forEachNdjsonRecord(stream, (value) => {
+    const record = normalizeRecord(value);
+    for (const key of Object.keys(record)) keys.add(key);
+  });
+
+  const columns = [...keys].sort((a, b) => a.localeCompare(b));
+  return columns.length > 0 ? columns : ["value"];
+}
+
+export function createCsvStreamFromNdjson(
+  stream: ReadableStream<Uint8Array>,
+  columns: string[]
+): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+
+  return new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        controller.enqueue(encoder.encode(CSV_BOM));
+        controller.enqueue(encoder.encode(`${columns.map(escapeCsvCell).join(",")}\n`));
+
+        await forEachNdjsonRecord(stream, (value) => {
+          const record = normalizeRecord(value);
+          const row = columns.map((column) => escapeCsvCell(stringifyScalar(record[column]))).join(",");
+          controller.enqueue(encoder.encode(`${row}\n`));
+        });
+
+        controller.close();
+      } catch (err) {
+        controller.error(err);
+      }
+    },
+    cancel() {
+      void stream.cancel().catch(() => {});
+    }
+  });
+}
+
+export async function convertNdjsonTextToCsvForTest(input: string): Promise<string> {
+  const bytes = new TextEncoder().encode(input);
+  const firstPass = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    }
+  });
+  const columns = await collectCsvColumnsFromNdjson(firstPass);
+
+  const secondPass = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    }
+  });
+  const csvStream = createCsvStreamFromNdjson(secondPass, columns);
+  const response = new Response(csvStream);
+  return response.text();
+}

--- a/apps/web/src/app/api/runs/[runId]/raw/route.ts
+++ b/apps/web/src/app/api/runs/[runId]/raw/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, type NextRequest } from "next/server";
+import { buildCsvDownloadResponse } from "./download-csv";
 
 function getApiBaseUrl(): string {
   const baseUrl = process.env.API_BASE_URL ?? process.env.NEXT_PUBLIC_API_BASE_URL;
@@ -11,25 +12,14 @@ export async function GET(req: NextRequest, ctx: { params: Promise<{ runId: stri
   if (!auth) return NextResponse.json({ error: "Missing Authorization header" }, { status: 401 });
 
   const { runId } = await ctx.params;
-
-  const res = await fetch(`${getApiBaseUrl()}/runs/${encodeURIComponent(runId)}/raw`, {
-    method: "GET",
-    headers: {
-      authorization: auth
-    }
+  const response = await buildCsvDownloadResponse({
+    runId,
+    auth,
+    apiBaseUrl: getApiBaseUrl()
   });
 
-  if (!res.ok) {
-    const data = await res.json().catch(async () => ({ error: await res.text() }));
-    return NextResponse.json(data, { status: res.status });
-  }
-
-  const headers = new Headers();
-  const contentType = res.headers.get("content-type");
-  if (contentType) headers.set("content-type", contentType);
-  const contentDisposition = res.headers.get("content-disposition");
-  if (contentDisposition) headers.set("content-disposition", contentDisposition);
-
-  return new NextResponse(res.body, { status: 200, headers });
+  return new NextResponse(response.body, {
+    status: response.status,
+    headers: response.headers
+  });
 }
-

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -17,11 +17,12 @@
 
 html,
 body {
-  height: 100%;
+  min-height: 100%;
 }
 
 body {
   margin: 0;
+  min-height: 100vh;
   background: radial-gradient(1200px 700px at 20% 10%, rgba(86, 215, 255, 0.25), transparent 60%),
     radial-gradient(900px 500px at 80% 30%, rgba(255, 184, 0, 0.18), transparent 55%),
     var(--bg);
@@ -52,7 +53,7 @@ a {
 }
 
 .appFrame {
-  height: 100%;
+  min-height: 100vh;
   display: grid;
   grid-template-rows: var(--topbar-h) 1fr;
 }
@@ -144,6 +145,7 @@ a {
   min-height: calc(100vh - var(--topbar-h));
   display: grid;
   grid-template-columns: auto 1fr;
+  align-items: start;
 }
 
 .appBody.hasSubnav {
@@ -307,6 +309,7 @@ a {
 
 .main {
   min-width: 0;
+  min-height: calc(100vh - var(--topbar-h));
 }
 
 .mainInner {
@@ -413,8 +416,29 @@ a {
   cursor: pointer;
 }
 
+.btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .btn:hover {
   border-color: rgba(86, 215, 255, 0.45);
+}
+
+.btnPrimary {
+  background: linear-gradient(180deg, rgba(116, 226, 255, 0.96), rgba(86, 215, 255, 0.9));
+  border-color: rgba(116, 226, 255, 0.98);
+  color: #082631;
+  font-weight: 700;
+}
+
+.btnPrimary:hover {
+  border-color: rgba(180, 240, 255, 1);
 }
 
 .table {

--- a/apps/web/src/app/runs/[runId]/run-details-client.tsx
+++ b/apps/web/src/app/runs/[runId]/run-details-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { Run, RunLogEntry } from "@accelerate-core/shared";
 import { useAuth } from "../../../lib/auth/AuthProvider";
@@ -9,7 +9,7 @@ type State =
   | { status: "idle" }
   | { status: "loading" }
   | { status: "error"; message: string }
-  | { status: "ready"; run: Run; rows?: Array<Record<string, unknown>>; rowsError?: string };
+  | { status: "ready"; run: Run };
 
 function oneLine(s: string): string {
   return s.replace(/\s+/g, " ").trim();
@@ -35,27 +35,6 @@ async function fetchRun(runId: string, idToken: string): Promise<Run> {
   }
 
   return json as Run;
-}
-
-async function fetchPreviewRows(input: { datasetId: string; versionId?: string; limit?: number }, idToken: string) {
-  const res = await fetch(`/api/query`, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-      authorization: `Bearer ${idToken}`
-    },
-    body: JSON.stringify(input)
-  });
-
-  const json = await res.json().catch(() => ({}));
-  if (!res.ok) {
-    const message = typeof json?.error === "string" ? json.error : `Request failed: ${res.status}`;
-    throw new Error(message);
-  }
-
-  const rows = json?.rows;
-  if (!Array.isArray(rows)) throw new Error("Invalid response");
-  return rows as Array<Record<string, unknown>>;
 }
 
 async function fetchRunLogs(input: { runId: string; afterTsMs?: number; limit?: number }, idToken: string) {
@@ -88,6 +67,10 @@ function formatLogLine(e: RunLogEntry): string {
   return `[${hh}] ${lvl} ${e.message}`;
 }
 
+function isNearBottom(el: HTMLElement, thresholdPx = 24): boolean {
+  return el.scrollHeight - (el.scrollTop + el.clientHeight) <= thresholdPx;
+}
+
 export function RunDetailsClient({ runId, onRunUpdate }: { runId: string; onRunUpdate?: (run: Run) => void }) {
   const { user, ready } = useAuth();
   const [state, setState] = useState<State>({ status: "idle" });
@@ -95,10 +78,10 @@ export function RunDetailsClient({ runId, onRunUpdate }: { runId: string; onRunU
   const [logsError, setLogsError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [busy, setBusy] = useState<null | "cancel" | "download">(null);
-  const [followLogs, setFollowLogs] = useState(true);
+  const [workerLogsPinned, setWorkerLogsPinned] = useState(true);
   const cursorRef = useRef<number>(0);
-  const apiLogRef = useRef<HTMLPreElement | null>(null);
   const workerLogRef = useRef<HTMLPreElement | null>(null);
+  const workerAutoFollowRef = useRef(true);
 
   const canLoad = useMemo(() => ready && !!user, [ready, user]);
 
@@ -145,6 +128,8 @@ export function RunDetailsClient({ runId, onRunUpdate }: { runId: string; onRunU
     setLogsError(null);
     setActionError(null);
     setBusy(null);
+    setWorkerLogsPinned(true);
+    workerAutoFollowRef.current = true;
     cursorRef.current = 0;
     void loadOnce();
     void loadLogsOnce();
@@ -167,14 +152,27 @@ export function RunDetailsClient({ runId, onRunUpdate }: { runId: string; onRunU
     };
   }, [canLoad, onRunUpdate, runId, user]);
 
+  const onWorkerLogScroll = useCallback(() => {
+    const workerEl = workerLogRef.current;
+    if (!workerEl) return;
+    const shouldFollow = isNearBottom(workerEl);
+    workerAutoFollowRef.current = shouldFollow;
+    setWorkerLogsPinned(shouldFollow);
+  }, []);
+
+  const jumpWorkerLogsToLatest = useCallback(() => {
+    const workerEl = workerLogRef.current;
+    if (!workerEl) return;
+    workerEl.scrollTop = workerEl.scrollHeight;
+    workerAutoFollowRef.current = true;
+    setWorkerLogsPinned(true);
+  }, []);
+
   useEffect(() => {
-    if (!followLogs) return;
-    // Scroll log panes to bottom when new logs arrive.
-    const apiEl = apiLogRef.current;
-    if (apiEl) apiEl.scrollTop = apiEl.scrollHeight;
+    if (!workerAutoFollowRef.current) return;
     const workerEl = workerLogRef.current;
     if (workerEl) workerEl.scrollTop = workerEl.scrollHeight;
-  }, [followLogs, logs.length]);
+  }, [logs.length]);
 
   if (!ready) return <p className="muted">Auth loading...</p>;
   if (!user) return <p className="muted">Sign in to view run details.</p>;
@@ -233,7 +231,7 @@ export function RunDetailsClient({ runId, onRunUpdate }: { runId: string; onRunU
 
       const a = document.createElement("a");
       a.href = url;
-      a.download = `${run.datasetId}-${run.id}.ndjson`;
+      a.download = `${run.datasetId}-${run.id}.csv`;
       document.body.appendChild(a);
       a.click();
       a.remove();
@@ -245,23 +243,6 @@ export function RunDetailsClient({ runId, onRunUpdate }: { runId: string; onRunU
     }
   };
 
-  const onPreview = async () => {
-    try {
-      const token = await user.getIdToken();
-      const rows = await fetchPreviewRows(
-        { datasetId: run.datasetId, versionId: run.outputs?.datasetVersionId, limit: 100 },
-        token
-      );
-      setState((prev) => (prev.status === "ready" ? { ...prev, rows, rowsError: undefined } : prev));
-    } catch (err) {
-      setState((prev) =>
-        prev.status === "ready"
-          ? { ...prev, rows: undefined, rowsError: err instanceof Error ? err.message : "Preview failed" }
-          : prev
-      );
-    }
-  };
-
   const apiLogs = logs.filter((e) => e.source === "api");
   const workerLogs = logs.filter((e) => e.source === "worker");
   const apiLogsText = apiLogs.map(formatLogLine).join("\n");
@@ -269,11 +250,20 @@ export function RunDetailsClient({ runId, onRunUpdate }: { runId: string; onRunU
 
   return (
     <div style={{ marginTop: 12 }}>
-      <div className="pill">
-        Status: <code>{run.status}</code>
-      </div>
-      <div style={{ marginTop: 10 }} className="muted">
-        Run ID: <code>{run.id}</code>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: 10, flexWrap: "wrap", alignItems: "flex-start" }}>
+        <div>
+          <div className="pill">
+            Status: <code>{run.status}</code>
+          </div>
+          <div style={{ marginTop: 10 }} className="muted">
+            Run ID: <code>{run.id}</code>
+          </div>
+        </div>
+        {run.outputs?.gcsRawNdjsonPath ? (
+          <button className="btn btnPrimary" type="button" onClick={onDownloadRaw} disabled={busy !== null}>
+            {busy === "download" ? "Downloading..." : "Download CSV"}
+          </button>
+        ) : null}
       </div>
       <div style={{ marginTop: 10 }} className="muted">
         Created by: {run.createdBy?.email ?? "unknown"}
@@ -301,8 +291,14 @@ export function RunDetailsClient({ runId, onRunUpdate }: { runId: string; onRunU
       ) : null}
       {run.outputs?.gcsRawNdjsonPath ? (
         <div style={{ marginTop: 10 }} className="muted">
-          Raw artifact: <code>{run.outputs.gcsRawNdjsonPath}</code>
+          Raw artifact: available
         </div>
+      ) : null}
+      {run.outputs?.gcsRawNdjsonPath ? (
+        <details style={{ marginTop: 8 }}>
+          <summary className="muted">Advanced: storage path</summary>
+          <pre className="logBlock">{run.outputs.gcsRawNdjsonPath}</pre>
+        </details>
       ) : null}
       {run.error?.message ? (
         <details className="errorDetails" style={{ marginTop: 10 }}>
@@ -313,24 +309,13 @@ export function RunDetailsClient({ runId, onRunUpdate }: { runId: string; onRunU
         </details>
       ) : null}
 
-      <div style={{ marginTop: 14, display: "flex", gap: 10, flexWrap: "wrap", alignItems: "center" }}>
-        {run.status === "queued" || run.status === "running" ? (
+      {run.status === "queued" || run.status === "running" ? (
+        <div style={{ marginTop: 14, display: "flex", gap: 10, flexWrap: "wrap", alignItems: "center" }}>
           <button className="btn" type="button" onClick={onCancel} disabled={busy !== null}>
             {busy === "cancel" ? "Stopping..." : "Stop run"}
           </button>
-        ) : null}
-        <button className="btn" type="button" onClick={onPreview} disabled={run.status !== "succeeded" || busy !== null}>
-          Preview rows (limit 100)
-        </button>
-        {run.outputs?.gcsRawNdjsonPath ? (
-          <button className="btn" type="button" onClick={onDownloadRaw} disabled={busy !== null}>
-            {busy === "download" ? "Downloading..." : "Download raw artifact"}
-          </button>
-        ) : null}
-        <button className="btn" type="button" onClick={() => setFollowLogs((v) => !v)} disabled={busy !== null}>
-          {followLogs ? "Following logs" : "Follow logs"}
-        </button>
-      </div>
+        </div>
+      ) : null}
 
       {actionError ? (
         <details className="errorDetails" style={{ marginTop: 10 }}>
@@ -342,11 +327,19 @@ export function RunDetailsClient({ runId, onRunUpdate }: { runId: string; onRunU
       ) : null}
 
       <div style={{ marginTop: 14 }}>
-        <div style={{ display: "flex", gap: 10, alignItems: "baseline", flexWrap: "wrap" }}>
-          <h3 style={{ margin: 0 }}>Logs</h3>
+        <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap" }}>
+          <h3 style={{ margin: 0 }}>Worker logs</h3>
           <span className="muted">
-            Updates while <code>queued</code>/<code>running</code>. (Run id: <code>{run.id}</code>)
+            Auto-updates while <code>queued</code>/<code>running</code>.
           </span>
+          {!workerLogsPinned && workerLogs.length > 0 ? (
+            <>
+              <span className="muted">Paused follow while you read older lines.</span>
+              <button className="btn" type="button" onClick={jumpWorkerLogsToLatest}>
+                Jump to latest
+              </button>
+            </>
+          ) : null}
         </div>
 
         {logsError ? (
@@ -358,64 +351,17 @@ export function RunDetailsClient({ runId, onRunUpdate }: { runId: string; onRunU
           </details>
         ) : null}
 
-        <div className="logGrid" style={{ marginTop: 10 }}>
-          <div className="card">
-            <div className="muted" style={{ marginBottom: 8 }}>
-              API logs
-            </div>
-            <pre ref={apiLogRef} className="logBlock">
-              {apiLogsText || "(no API log entries yet)"}
-            </pre>
-          </div>
-          <div className="card">
-            <div className="muted" style={{ marginBottom: 8 }}>
-              Worker logs
-            </div>
-            <pre ref={workerLogRef} className="logBlock">
-              {workerLogsText || "(no worker log entries yet)"}
-            </pre>
-          </div>
-        </div>
-      </div>
+        <pre ref={workerLogRef} className="logBlock" style={{ marginTop: 10, maxHeight: 360 }} onScroll={onWorkerLogScroll}>
+          {workerLogsText || "(no worker log entries yet)"}
+        </pre>
 
-      {state.rowsError ? (
-        <details className="errorDetails" style={{ marginTop: 10 }}>
+        <details style={{ marginTop: 12 }}>
           <summary className="muted">
-            Preview error: <code>{truncate(oneLine(state.rowsError), 200)}</code>
+            API events (<code>{apiLogs.length}</code>)
           </summary>
-          <pre className="logBlock">{state.rowsError}</pre>
+          <pre className="logBlock">{apiLogsText || "(no API events yet)"}</pre>
         </details>
-      ) : null}
-
-      {state.rows && state.rows.length > 0 ? (
-        <div style={{ marginTop: 14 }}>
-          <div className="muted" style={{ marginBottom: 8 }}>
-            Preview ({state.rows.length} rows)
-          </div>
-          <div style={{ overflowX: "auto" }}>
-            <table className="table">
-              <thead>
-                <tr>
-                  {Object.keys(state.rows[0] ?? {}).map((k) => (
-                    <th key={k}>{k}</th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {state.rows.map((row, idx) => (
-                  <tr key={idx}>
-                    {Object.keys(state.rows![0] ?? {}).map((k) => (
-                      <td key={k}>
-                        <code>{typeof row[k] === "string" ? row[k] : JSON.stringify(row[k])}</code>
-                      </td>
-                    ))}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      ) : null}
+      </div>
     </div>
   );
 }

--- a/apps/web/test/ndjson-to-csv.test.ts
+++ b/apps/web/test/ndjson-to-csv.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { convertNdjsonTextToCsvForTest } from "../src/app/api/runs/[runId]/raw/ndjson-to-csv.ts";
+
+function parseCsv(inputRaw: string): string[][] {
+  const input = inputRaw.startsWith("\uFEFF") ? inputRaw.slice(1) : inputRaw;
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const ch = input[i]!;
+
+    if (inQuotes) {
+      if (ch === "\"") {
+        const next = input[i + 1];
+        if (next === "\"") {
+          cell += "\"";
+          i += 1;
+          continue;
+        }
+        inQuotes = false;
+        continue;
+      }
+      cell += ch;
+      continue;
+    }
+
+    if (ch === "\"") {
+      inQuotes = true;
+      continue;
+    }
+    if (ch === ",") {
+      row.push(cell);
+      cell = "";
+      continue;
+    }
+    if (ch === "\n") {
+      row.push(cell);
+      rows.push(row);
+      row = [];
+      cell = "";
+      continue;
+    }
+    if (ch === "\r") {
+      continue;
+    }
+    cell += ch;
+  }
+
+  if (cell.length > 0 || row.length > 0) {
+    row.push(cell);
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+test("NDJSON converts to CSV with stable headers, escaping, and missing values", async () => {
+  const ndjson = [
+    JSON.stringify({
+      id: 1,
+      name: "Alice",
+      note: "hello, world",
+      quote: "He said \"yes\"",
+      multiline: "line-1\nline-2",
+      empty: null,
+      meta: { region: "east" },
+      tags: ["a", "b"]
+    }),
+    JSON.stringify({
+      id: 2,
+      name: "Bob",
+      active: true,
+      extra: "present"
+    })
+  ].join("\n");
+
+  const csv = await convertNdjsonTextToCsvForTest(ndjson);
+  const rows = parseCsv(csv);
+
+  assert.equal(rows.length, 3);
+  assert.deepEqual(rows[0], ["active", "empty", "extra", "id", "meta", "multiline", "name", "note", "quote", "tags"]);
+
+  const header = rows[0]!;
+  const row1 = Object.fromEntries(header.map((key, idx) => [key, rows[1]![idx]]));
+  const row2 = Object.fromEntries(header.map((key, idx) => [key, rows[2]![idx]]));
+
+  assert.equal(row1.active, "");
+  assert.equal(row1.empty, "");
+  assert.equal(row1.extra, "");
+  assert.equal(row1.id, "1");
+  assert.equal(row1.meta, "{\"region\":\"east\"}");
+  assert.equal(row1.multiline, "line-1\nline-2");
+  assert.equal(row1.name, "Alice");
+  assert.equal(row1.note, "hello, world");
+  assert.equal(row1.quote, "He said \"yes\"");
+  assert.equal(row1.tags, "[\"a\",\"b\"]");
+
+  assert.equal(row2.active, "true");
+  assert.equal(row2.empty, "");
+  assert.equal(row2.extra, "present");
+  assert.equal(row2.id, "2");
+  assert.equal(row2.meta, "");
+  assert.equal(row2.multiline, "");
+  assert.equal(row2.name, "Bob");
+  assert.equal(row2.note, "");
+  assert.equal(row2.quote, "");
+  assert.equal(row2.tags, "");
+});

--- a/apps/web/test/raw-route.test.ts
+++ b/apps/web/test/raw-route.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildCsvDownloadResponse } from "../src/app/api/runs/[runId]/raw/download-csv.ts";
+
+function parseCsv(inputRaw: string): string[][] {
+  const input = inputRaw.startsWith("\uFEFF") ? inputRaw.slice(1) : inputRaw;
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let cell = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const ch = input[i]!;
+
+    if (inQuotes) {
+      if (ch === "\"") {
+        const next = input[i + 1];
+        if (next === "\"") {
+          cell += "\"";
+          i += 1;
+          continue;
+        }
+        inQuotes = false;
+        continue;
+      }
+      cell += ch;
+      continue;
+    }
+
+    if (ch === "\"") {
+      inQuotes = true;
+      continue;
+    }
+    if (ch === ",") {
+      row.push(cell);
+      cell = "";
+      continue;
+    }
+    if (ch === "\n") {
+      row.push(cell);
+      rows.push(row);
+      row = [];
+      cell = "";
+      continue;
+    }
+    if (ch === "\r") {
+      continue;
+    }
+    cell += ch;
+  }
+
+  if (cell.length > 0 || row.length > 0) {
+    row.push(cell);
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+test("download handler returns CSV stream with csv headers and filename", async () => {
+  const ndjson = [JSON.stringify({ id: 1, name: "Alice" }), JSON.stringify({ id: 2, name: "Bob" })].join("\n");
+  let fetchCalls = 0;
+
+  const fetchImpl: typeof fetch = async (input, init) => {
+    fetchCalls += 1;
+    assert.equal(String(input), "https://example.internal/runs/run-123/raw");
+    const authHeader = new Headers(init?.headers).get("authorization");
+    assert.equal(authHeader, "Bearer token");
+
+    return new Response(ndjson, {
+      status: 200,
+      headers: {
+        "content-type": "application/x-ndjson",
+        "content-disposition": "attachment; filename=\"pgic_people_groups-run-123.ndjson\""
+      }
+    });
+  };
+
+  const response = await buildCsvDownloadResponse({
+    runId: "run-123",
+    auth: "Bearer token",
+    apiBaseUrl: "https://example.internal",
+    fetchImpl
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get("content-type"), "text/csv; charset=utf-8");
+  assert.equal(response.headers.get("content-disposition"), "attachment; filename=\"pgic_people_groups-run-123.csv\"");
+  assert.equal(fetchCalls, 2);
+
+  const rows = parseCsv(await response.text());
+  assert.deepEqual(rows, [
+    ["id", "name"],
+    ["1", "Alice"],
+    ["2", "Bob"]
+  ]);
+});

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -10,6 +10,7 @@
     "moduleResolution": "Bundler",
     "jsx": "preserve",
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "types": [
       "node"
     ],


### PR DESCRIPTION
## Summary
- convert run artifact downloads from NDJSON to CSV in the web `/api/runs/[runId]/raw` path
- keep NDJSON as internal storage format; convert at download-time
- improve Run Details UX: primary `Download CSV`, auto-follow worker logs with jump-to-latest, and move raw path to Advanced
- add web tests for converter + download handler
- codify ship workflow in AGENTS docs (test/commit/merge/cleanup/redeploy)

## Why convert-at-download
- avoids changes to worker artifact generation and BigQuery ingestion
- preserves internal NDJSON workflows while delivering end-user CSV output
- conversion uses streaming and bounded memory

## CSV schema behavior
- columns = union of keys across all records
- ordering = deterministic alphabetical
- missing keys => blank cells
- nested objects/arrays => JSON string in one cell
- proper CSV escaping for quotes/commas/newlines

## Validation
- `pnpm --filter @accelerate-core/web run test`
- `pnpm --filter @accelerate-core/web run typecheck`
- `pnpm --filter @accelerate-core/web run lint`
- `pnpm --filter @accelerate-core/web run build`
