### PR TITLE
Use OIDC auth for App Hosting deploy workflow

### DIFF
--- a/.github/workflows/deploy-web-apphosting.yml
+++ b/.github/workflows/deploy-web-apphosting.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          workload_identity_provider: projects/336107567511/locations/global/workloadIdentityPools/github-actions/providers/github
+          service_account: gh-apphost-deployer@accelerate-global-473318.iam.gserviceaccount.com
 
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v2


### PR DESCRIPTION
## Summary
- switch the deploy workflow auth step from repo secrets to direct GitHub OIDC provider + service account
- use provider: `projects/336107567511/locations/global/workloadIdentityPools/github-actions/providers/github`
- use service account: `gh-apphost-deployer@accelerate-global-473318.iam.gserviceaccount.com`

## Why
- the initial workflow run failed because no auth secrets were configured
- OIDC removes secret management overhead and keeps deploy authority in GitHub Actions only
