### PR TITLE
Add AGENTS compressed index workflow and agent docs

### DIFF
--- a/.agent-docs/env.md
+++ b/.agent-docs/env.md
@@ -1,0 +1,37 @@
+# Environment Variables
+
+This repo expects environment variables to be provided by deploy-time configuration (Secret Manager or service config), not hardcoded in source.
+
+## Authorization / Access Control
+- `ALLOWED_ADMIN_EMAILS`: comma-separated exact emails enforced by API/Worker. Missing/empty should be treated as fail-closed for privileged endpoints.
+- `NEXT_PUBLIC_ALLOWED_ADMIN_EMAILS`: web-only UI gating hint; not enforcement.
+- `DEV_AUTH_EMAIL`: local/dev bypass identity for non-production runs.
+- `WORKER_AUTH_MODE`: worker auth mode (`iam` default, optional `firebase`).
+
+## Service Wiring
+- `API_BASE_URL`: preferred server-side base URL for web proxy routes.
+- `NEXT_PUBLIC_API_BASE_URL`: fallback API base URL.
+- `WORKER_BASE_URL`: API target URL for worker trigger endpoint.
+- `PORT`, `HOST`: runtime server bind values.
+
+## GCP / Data Plane
+- `GOOGLE_CLOUD_PROJECT`: project id override for runtime clients.
+- `BIGQUERY_DATASET`: BigQuery dataset override (default falls back to shared constant).
+- `BIGQUERY_LOCATION`: BigQuery location (default `US`).
+- `ARTIFACTS_BUCKET`: GCS bucket for run artifacts.
+
+## Firebase Web Config
+- `NEXT_PUBLIC_FIREBASE_API_KEY`
+- `NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN`
+- `NEXT_PUBLIC_FIREBASE_PROJECT_ID`
+- `NEXT_PUBLIC_FIREBASE_APP_ID`
+
+## Connector Variables
+- `JOSHUA_PROJECT_API_KEY`: required connector secret.
+- `JOSHUA_PROJECT_BASE_URL`: optional connector endpoint override.
+- `JOSHUA_PROJECT_LIMIT`: optional record limit override.
+
+## Gotchas
+- Never commit real values for secret-bearing variables.
+- Web allowlist vars do not authorize backend actions.
+- Keep env defaults aligned with shared constants in `packages/shared/src/index.ts`.

--- a/.agent-docs/overview.md
+++ b/.agent-docs/overview.md
@@ -1,0 +1,30 @@
+# Accelerate Core Overview
+
+Accelerate Core is a V1 monorepo for an internal ingestion control plane.
+
+## Services
+- `apps/web`: Next.js admin UI on Firebase App Hosting.
+- `apps/api`: Fastify HTTP API on Cloud Run.
+- `apps/worker`: sequential runner service on Cloud Run.
+- `packages/shared`: shared constants/types/contracts.
+- `packages/firestore`: Firestore data access layer and run logging helpers.
+- `packages/bq`: BigQuery helpers for preview and loads.
+- `packages/connectors`: connector framework + registry.
+- `packages/connectors/joshuaproject`: current connector implementation.
+- `infra/firebase`: Firebase config/rules/index placeholders.
+
+## Core Data Flow
+1. Web calls API via Next route handlers under `apps/web/src/app/api`.
+2. API creates/updates run state in Firestore and triggers worker.
+3. Worker runs connector, stores artifacts in GCS, loads BigQuery versioned tables, and finalizes run state.
+4. Web reads run status/logs and resource snapshots through API proxies.
+
+## Immutable Identifiers (Do Not Change)
+- GCP project: `accelerate-global-473318`
+- Firebase project: `accelerate-global-473318`
+- BigQuery dataset (default): `accelerate_dev`
+- First dataset slug: `pgic_people_groups`
+
+## Source of Truth
+- Folder-level `AGENTS.md` files define local policy/commands/contracts.
+- Root `AGENTS.md` defines repo-wide policy and the compressed retriever index.

--- a/.agent-docs/workflows.md
+++ b/.agent-docs/workflows.md
@@ -1,0 +1,33 @@
+# Key Workflows
+
+## Development Workflow
+1. Install dependencies: `pnpm install`
+2. Implement changes in the relevant package/app.
+3. Run checks for touched areas: `pnpm run lint`, `pnpm run typecheck`, targeted tests, then `pnpm run test`.
+4. Update agent docs when behavior/contracts/workflows change.
+5. Regenerate the AGENTS index: `npm run agents:index` (or `pnpm run agents:index`).
+6. Validate index freshness: `npm run agents:check`.
+
+## Release Workflow (Mandatory)
+1. Commit changes to a feature branch.
+2. Push branch and open a PR.
+3. Merge PR to `main`.
+4. Return local repo to `main`.
+5. Clean merged branches:
+- `git fetch --prune`
+- `git branch -d <branch-name>`
+- `git push origin --delete <branch-name>`
+6. Confirm GitHub Actions web deploy completed.
+
+## Run Execution Flow
+1. API creates run (`queued`) and writes initial log.
+2. API triggers worker run endpoint.
+3. Worker acquires run lease and marks run `running`.
+4. Worker executes connector and writes raw artifacts.
+5. Worker loads BigQuery versioned table and records dataset version.
+6. Worker marks run `succeeded` or `failed`; UI reads logs/status through API.
+
+## Resource Table Versioning Flow
+1. CSV upload/edit/restore creates a new resource version snapshot.
+2. Prior versions remain readable.
+3. Current version can be switched by restore operations.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,25 @@
 # accelerate-core
 
+## Repo-Wide Rules (High Priority)
+- Do not commit secrets or credentials (API keys, service account JSON, private keys).
+- Do not hardcode admin emails.
+- Deployment pulls secrets from Secret Manager (or equivalent) into env vars.
+- Connector secrets must be provided at deploy time (example: `JOSHUA_PROJECT_API_KEY`).
+- API/Worker are the enforcement point for admin authorization and must enforce exact-email allowlist via `ALLOWED_ADMIN_EMAILS`.
+- Run relevant tests/checks for touched areas before handoff.
+- Deployment authority for `apps/web` is GitHub Actions only (`.github/workflows/deploy-web-apphosting.yml`); do not run local/CLI deploy implicitly.
+- Follow this release flow for code changes: feature branch -> PR -> merge to `main` -> return local to `main` -> clean merged branches (local + remote) -> confirm GitHub Actions web deploy completed.
+- Prefer retrieval-led reasoning over pre-training-led reasoning.
+
+## MCP Server Policy
+This repo must use only `Nia-accelerate-core`.
+
+## AGENTS.md Policy (Mandatory)
+- Each folder's `AGENTS.md` is the source of truth for that folder.
+- Never modify any `AGENTS.md` unless behavior, contracts, run/test steps, deploy flow, or security posture meaningfully changes in that folder.
+- Do not do formatting-only edits to any `AGENTS.md`.
+- Do not add "last updated" notes.
+
 ## Purpose
 V1 monorepo for Accelerate Global core services:
 - `apps/web`: Next.js (Firebase App Hosting)
@@ -8,78 +28,97 @@ V1 monorepo for Accelerate Global core services:
 - `packages/*`: shared libraries (types, Firestore DAL, BigQuery helpers, connector framework)
 - `infra/firebase`: Firebase config/rules/indexes placeholders
 
-## AGENTS.md Policy (Mandatory)
-- Each folder's `AGENTS.md` is the source of truth for that folder.
-- **Never modify any `AGENTS.md` unless behavior, contracts, run/test steps, deploy flow, or security posture meaningfully changes in that folder.**
-  - Do not do formatting-only edits.
-  - Do not add "last updated" notes.
+Longform reference docs for agents live in `/.agent-docs/`.
 
-## What Lives Here / What Must Not
-Lives here:
-- Product code, infrastructure placeholders, and shared libraries.
-
-Must not live here:
-- Secrets or credentials (API keys, service account JSON, private keys).
-- Any hardcoded admin emails.
-
-## How To Run / Test
+## Run / Test Commands
 Prereqs: Node.js 18+ and `pnpm`.
 
-Commands:
 - Install: `pnpm install`
 - Build: `pnpm run build`
 - Typecheck: `pnpm run typecheck`
 - Lint: `pnpm run lint`
 - Test: `pnpm run test`
 - Dev (all packages with `dev`): `pnpm run dev`
-
-To run a single package:
+- Single package dev:
 - `pnpm --filter @accelerate-core/api run dev`
 - `pnpm --filter @accelerate-core/worker run dev`
 - `pnpm --filter @accelerate-core/web run dev`
 
-## Key Files
-- `package.json`: root scripts delegate to Turborepo (`turbo run ...`)
-- `pnpm-workspace.yaml`: workspace package globs
-- `turbo.json`: build/lint/typecheck/test/dev task graph
-- `tsconfig.base.json`: shared TypeScript defaults
-- `infra/firebase/`: Firebase placeholders (rules/indexes/config)
-
 ## Interfaces / Contracts
 - Admin allowlist (V1 internal-only):
-  - API/Worker enforce allowlist by exact email via `ALLOWED_ADMIN_EMAILS="a@b.com,c@d.com"`.
-  - Web may hide admin UI when not allowlisted, but **API/Worker are the enforcement point**.
+- API/Worker enforce allowlist by exact email via `ALLOWED_ADMIN_EMAILS="a@b.com,c@d.com"`.
+- Web may hide admin UI when not allowlisted, but API/Worker are the enforcement point.
 - Identifiers (do not change):
-  - GCP Project ID: `accelerate-global-473318`
-  - Firebase project: `accelerate-global-473318`
-  - BigQuery dataset: `accelerate_dev`
-  - First dataset slug: `pgic_people_groups`
+- GCP Project ID: `accelerate-global-473318`
+- Firebase project: `accelerate-global-473318`
+- BigQuery dataset: `accelerate_dev`
+- First dataset slug: `pgic_people_groups`
 - Resources (V1):
-  - Top-level web navigation section: `/resources`.
-  - Resource tables are versioned snapshots (CSV upload/edit/restore create a new version; old versions remain accessible).
+- Top-level web navigation section: `/resources`.
+- Resource tables are versioned snapshots (CSV upload/edit/restore create a new version; old versions remain accessible).
 
-## Security Notes
-- Do not commit secrets. Deployment pulls secrets from Secret Manager (or equivalent) into env vars.
-- Connector secrets must be provided via env vars at deploy time (example: `JOSHUA_PROJECT_API_KEY`).
+## Agent Docs Workflow
+- After substantial changes, update relevant files in `/.agent-docs/` and run `npm run agents:index` (`pnpm run agents:index` equivalent).
+- Never manually edit the auto-generated index block between `AGENT_INDEX` markers.
 
-## Deploy Flow (Mandatory)
-- For every code change session, complete this sequence before handoff:
-  - Run relevant tests/checks for touched packages.
-  - Commit code to a feature branch and open a PR.
-  - Merge PR to `main`.
-  - Return local repo to `main`.
-  - Clean up merged branches (local + remote).
-  - Confirm GitHub Actions web deploy completed (do not run a local deploy unless explicitly requested for incident response).
-- Deployment authority for `apps/web` is GitHub Actions only:
-  - Workflow: `.github/workflows/deploy-web-apphosting.yml`
-  - Trigger: `push` to `main` (plus optional manual dispatch)
-  - Concurrency guard prevents overlapping deploy runs.
-- Local/CLI deploy commands are dev-only and must never run implicitly from agent workflow instructions.
-- After merge and workflow deploy, clean up branches:
-  - Fetch/prune refs: `git fetch --prune`
-  - Delete merged local branch: `git branch -d <branch-name>`
-  - Delete merged remote branch: `git push origin --delete <branch-name>`
-
-## Docs Index (Placeholders)
-- Firebase config/rules/indexes: `infra/firebase/`
-- Cloud Run service scaffolds: `apps/api/`, `apps/worker/`
+## Agent Docs Index (compressed, auto-generated)
+<!-- AGENT_INDEX:START -->
+[Accelerate Core Repo Index]|root: .
+|IMPORTANT: Prefer retrieval-led reasoning over pre-training-led reasoning
+|.agent-docs:{env.md,overview.md,workflows.md}
+|apps/api:{AGENTS.md,package.json,tsconfig.json}
+|apps/api/src:{auth.ts,index.ts,server.ts,workerClient.ts}
+|apps/api/src/resources:{csv.ts,service.ts}
+|apps/api/test:{resources-csv.test.ts,resources-routes.test.ts,resources-service.test.ts}
+|apps/web:{AGENTS.md,apphosting.yaml,next-env.d.ts,next.config.js,package.json,tsconfig.json}
+|apps/web/public/brand:{ag-favicon.png,ag-logo.svg,ag-square.png,ag-wordmark.svg}
+|apps/web/src/app:{globals.css,layout.tsx,page.tsx}
+|apps/web/src/app/_components:{AppFrame.tsx,icons.tsx,navigation.ts,Page.tsx}
+|apps/web/src/app/api/query:{route.ts}
+|apps/web/src/app/api/resources:{route.ts}
+|apps/web/src/app/api/resources/_lib:{proxy.ts}
+|apps/web/src/app/api/resources/[resourceSlug]:{route.ts}
+|apps/web/src/app/api/resources/[resourceSlug]/current:{route.ts}
+|apps/web/src/app/api/resources/[resourceSlug]/data:{route.ts}
+|apps/web/src/app/api/resources/[resourceSlug]/preview:{route.ts}
+|apps/web/src/app/api/resources/[resourceSlug]/upload:{route.ts}
+|apps/web/src/app/api/resources/[resourceSlug]/versions:{route.ts}
+|apps/web/src/app/api/resources/[resourceSlug]/versions/[versionId]:{route.ts}
+|apps/web/src/app/api/resources/[resourceSlug]/versions/[versionId]/restore:{route.ts}
+|apps/web/src/app/api/runs:{route.ts}
+|apps/web/src/app/api/runs/[runId]:{route.ts}
+|apps/web/src/app/api/runs/[runId]/cancel:{route.ts}
+|apps/web/src/app/api/runs/[runId]/logs:{route.ts}
+|apps/web/src/app/api/runs/[runId]/raw:{download-csv.ts,ndjson-to-csv.ts,route.ts}
+|apps/web/src/app/connectors:{page.tsx,ui.tsx}
+|apps/web/src/app/connectors/joshuaproject:{joshuaproject-client.tsx,page.tsx}
+|apps/web/src/app/datasets:{page.tsx}
+|apps/web/src/app/datasets/pgic_people_groups:{dataset-client.tsx,page.tsx}
+|apps/web/src/app/resources:{page.tsx}
+|apps/web/src/app/resources/_components:{resource-table-editor.tsx}
+|apps/web/src/app/resources/_lib:{client-api.ts}
+|apps/web/src/app/resources/tables:{page.tsx,tables-client.tsx}
+|apps/web/src/app/resources/tables/[resourceSlug]:{page.tsx,resource-detail-client.tsx}
+|apps/web/src/app/resources/tables/[resourceSlug]/versions:{page.tsx,versions-client.tsx}
+|apps/web/src/app/resources/tables/[resourceSlug]/versions/[versionId]:{page.tsx,version-snapshot-client.tsx}
+|apps/web/src/app/runs:{page.tsx,runs-client.tsx}
+|apps/web/src/app/runs/[runId]:{page.tsx,run-details-client.tsx}
+|apps/web/src/lib:{admin.ts}
+|apps/web/src/lib/auth:{AuthControls.tsx,AuthProvider.tsx}
+|apps/web/src/lib/firebase:{client.ts}
+|apps/web/test:{ndjson-to-csv.test.ts,raw-route.test.ts,resources-navigation.test.ts}
+|apps/worker:{AGENTS.md,package.json,tsconfig.json}
+|apps/worker/src:{auth.ts,index.ts,runner.ts,server.ts}
+|infra/firebase:{AGENTS.md,firebase.json,firestore.indexes.json,firestore.rules}
+|packages/bq:{AGENTS.md,package.json,tsconfig.json}
+|packages/bq/src:{index.ts}
+|packages/connectors:{AGENTS.md,package.json,tsconfig.json}
+|packages/connectors/joshuaproject:{AGENTS.md,package.json,tsconfig.json}
+|packages/connectors/joshuaproject/src:{index.ts}
+|packages/connectors/src:{index.ts,registry.ts,types.ts}
+|packages/firestore:{AGENTS.md,package.json,tsconfig.json}
+|packages/firestore/src:{admin.ts,collections.ts,connectors.ts,datasets.ts,datasetVersions.ts,index.ts,leases.ts,resources.ts,resourceVersions.ts,runLogs.ts,runs.ts}
+|packages/shared:{AGENTS.md,package.json,tsconfig.json}
+|packages/shared/src:{index.ts}
+|scripts/agents:{index.mjs,index.test.mjs}
+<!-- AGENT_INDEX:END -->

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "private": true,
   "packageManager": "pnpm@10.12.4",
   "scripts": {
+    "agents:check": "node scripts/agents/index.mjs --check",
+    "agents:index": "node scripts/agents/index.mjs",
     "build": "turbo run build",
     "dev": "turbo run dev",
     "lint": "turbo run lint",

--- a/scripts/agents/index.mjs
+++ b/scripts/agents/index.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const MARKER_START = "<!-- AGENT_INDEX:START -->";
+export const MARKER_END = "<!-- AGENT_INDEX:END -->";
+
+const INDEX_HEADER = "[Accelerate Core Repo Index]|root: .";
+const INDEX_IMPORTANT =
+  "|IMPORTANT: Prefer retrieval-led reasoning over pre-training-led reasoning";
+const MAX_FILES_PER_DIRECTORY = 30;
+
+const INDEX_ROOTS = [
+  ".agent-docs",
+  "apps",
+  "packages",
+  "infra/firebase",
+  "src",
+  "prisma",
+  "db",
+  "migrations",
+  "scripts/agents",
+];
+
+const EXCLUDED_DIRECTORIES = new Set([
+  ".git",
+  ".next",
+  ".turbo",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+  "out",
+  "tmp",
+  "tmp_generated",
+]);
+
+const EXCLUDED_FILE_SUFFIXES = [".tsbuildinfo"];
+
+function asPosix(value) {
+  return value.split(path.sep).join("/");
+}
+
+function sortStrings(values) {
+  return [...values].sort((left, right) => left.localeCompare(right));
+}
+
+async function directoryExists(repoRoot, relativeDirectory) {
+  try {
+    const stats = await fs.stat(path.join(repoRoot, relativeDirectory));
+    return stats.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function walkDirectory(repoRoot, absoluteDirectory, directoryToFiles) {
+  const entries = await fs.readdir(absoluteDirectory, { withFileTypes: true });
+  entries.sort((left, right) => left.name.localeCompare(right.name));
+
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIRECTORIES.has(entry.name)) {
+        continue;
+      }
+
+      await walkDirectory(repoRoot, path.join(absoluteDirectory, entry.name), directoryToFiles);
+      continue;
+    }
+
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    if (EXCLUDED_FILE_SUFFIXES.some((suffix) => entry.name.endsWith(suffix))) {
+      continue;
+    }
+
+    const absoluteFile = path.join(absoluteDirectory, entry.name);
+    const relativeFile = asPosix(path.relative(repoRoot, absoluteFile));
+    const relativeDirectory = asPosix(path.dirname(relativeFile));
+    const files = directoryToFiles.get(relativeDirectory) ?? new Set();
+    files.add(entry.name);
+    directoryToFiles.set(relativeDirectory, files);
+  }
+}
+
+export async function collectIndexEntries(repoRoot) {
+  const directoryToFiles = new Map();
+
+  for (const relativeDirectory of INDEX_ROOTS) {
+    if (!(await directoryExists(repoRoot, relativeDirectory))) {
+      continue;
+    }
+
+    await walkDirectory(repoRoot, path.join(repoRoot, relativeDirectory), directoryToFiles);
+  }
+
+  return directoryToFiles;
+}
+
+export function buildIndexLines(directoryToFiles, maxFilesPerDirectory = MAX_FILES_PER_DIRECTORY) {
+  const lines = [INDEX_HEADER, INDEX_IMPORTANT];
+  const directories = sortStrings(directoryToFiles.keys());
+
+  for (const directory of directories) {
+    const files = sortStrings(directoryToFiles.get(directory) ?? []);
+    const visibleFiles = files.slice(0, maxFilesPerDirectory);
+    const hiddenCount = files.length - visibleFiles.length;
+    if (hiddenCount > 0) {
+      visibleFiles.push(`...+${hiddenCount}`);
+    }
+
+    lines.push(`|${directory}:{${visibleFiles.join(",")}}`);
+  }
+
+  return lines;
+}
+
+export function buildIndexBlock(directoryToFiles, maxFilesPerDirectory = MAX_FILES_PER_DIRECTORY) {
+  return buildIndexLines(directoryToFiles, maxFilesPerDirectory).join("\n");
+}
+
+export function injectGeneratedIndex(agentsContent, indexBlock) {
+  const startIndex = agentsContent.indexOf(MARKER_START);
+  const endIndex = agentsContent.indexOf(MARKER_END, startIndex);
+
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    throw new Error(
+      `Could not find AGENT_INDEX markers in AGENTS.md. Expected ${MARKER_START} and ${MARKER_END}.`
+    );
+  }
+
+  const prefix = agentsContent.slice(0, startIndex + MARKER_START.length);
+  const suffix = agentsContent.slice(endIndex);
+  return `${prefix}\n${indexBlock}\n${suffix}`;
+}
+
+export async function generateUpdatedAgentsContent(repoRoot, agentsFile = "AGENTS.md") {
+  const agentsPath = path.join(repoRoot, agentsFile);
+  const currentContent = await fs.readFile(agentsPath, "utf8");
+  const directoryToFiles = await collectIndexEntries(repoRoot);
+  const indexBlock = buildIndexBlock(directoryToFiles);
+  const updatedContent = injectGeneratedIndex(currentContent, indexBlock);
+
+  return { agentsPath, currentContent, updatedContent, indexBlock };
+}
+
+function parseArgs(argv) {
+  const checkOnly = argv.includes("--check");
+  const unsupported = argv.filter((arg) => arg !== "--check");
+  if (unsupported.length > 0) {
+    throw new Error(`Unsupported arguments: ${unsupported.join(", ")}`);
+  }
+
+  return { checkOnly };
+}
+
+export async function runCli(argv = process.argv.slice(2), repoRoot = process.cwd()) {
+  const { checkOnly } = parseArgs(argv);
+  const { agentsPath, currentContent, updatedContent } = await generateUpdatedAgentsContent(repoRoot);
+
+  if (checkOnly) {
+    if (updatedContent !== currentContent) {
+      process.stderr.write("AGENTS.md index is out of date. Run `npm run agents:index`.\n");
+      return 1;
+    }
+
+    process.stdout.write("AGENTS.md index is up to date.\n");
+    return 0;
+  }
+
+  if (updatedContent !== currentContent) {
+    await fs.writeFile(agentsPath, updatedContent, "utf8");
+    process.stdout.write("AGENTS.md index updated.\n");
+  } else {
+    process.stdout.write("AGENTS.md index already up to date.\n");
+  }
+
+  return 0;
+}
+
+const isCliEntryPoint =
+  process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isCliEntryPoint) {
+  runCli()
+    .then((exitCode) => {
+      process.exitCode = exitCode;
+    })
+    .catch((error) => {
+      process.stderr.write(`${error.message}\n`);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/agents/index.test.mjs
+++ b/scripts/agents/index.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildIndexLines,
+  injectGeneratedIndex,
+  MARKER_END,
+  MARKER_START,
+} from "./index.mjs";
+
+test("buildIndexLines sorts directories and files deterministically", () => {
+  const directoryToFiles = new Map([
+    ["packages/beta", new Set(["z.ts", "a.ts"])],
+    [".agent-docs", new Set(["workflows.md", "env.md", "overview.md"])],
+  ]);
+
+  const lines = buildIndexLines(directoryToFiles, 30);
+
+  assert.equal(lines[0], "[Accelerate Core Repo Index]|root: .");
+  assert.equal(
+    lines[1],
+    "|IMPORTANT: Prefer retrieval-led reasoning over pre-training-led reasoning"
+  );
+  assert.equal(lines[2], "|.agent-docs:{env.md,overview.md,workflows.md}");
+  assert.equal(lines[3], "|packages/beta:{a.ts,z.ts}");
+});
+
+test("buildIndexLines truncates long directory listings with +N", () => {
+  const files = new Set(
+    Array.from({ length: 33 }, (_, index) => `file-${String(index + 1).padStart(2, "0")}.ts`)
+  );
+  const directoryToFiles = new Map([["apps/api/src", files]]);
+
+  const lines = buildIndexLines(directoryToFiles, 30);
+  const sourceLine = lines.find((line) => line.startsWith("|apps/api/src:{"));
+
+  assert.ok(sourceLine, "expected line for apps/api/src");
+  assert.match(sourceLine, /\.\.\.\+3\}/);
+});
+
+test("injectGeneratedIndex replaces only the marker block", () => {
+  const current = [
+    "# header",
+    MARKER_START,
+    "old index",
+    MARKER_END,
+    "footer",
+  ].join("\n");
+
+  const updated = injectGeneratedIndex(current, "new index");
+
+  assert.equal(
+    updated,
+    ["# header", MARKER_START, "new index", MARKER_END, "footer"].join("\n")
+  );
+});
+
+test("injectGeneratedIndex throws if markers are missing", () => {
+  assert.throws(() => injectGeneratedIndex("# header", "new index"));
+});


### PR DESCRIPTION
## Summary
- reorganize root AGENTS.md so repo-wide policy and workflow rules are top-priority
- add `.agent-docs/` with concise overview/workflows/env references for retrieval-led reasoning
- add deterministic generator at `scripts/agents/index.mjs` to update only the AGENT_INDEX marker block
- add `agents:index` and `agents:check` scripts to root `package.json`

## New workflow
After substantial repo changes, update relevant docs under `.agent-docs/` and run `npm run agents:index`.
Do not manually edit the auto-generated index block in AGENTS.md.

## Validation
- npm run agents:index
- npm run agents:check
- node --test scripts/agents/index.test.mjs
- pnpm run lint
- pnpm run typecheck
- pnpm run test
