### PR TITLE
[codex] T3: Add Route Groups, Zone Layouts, and Error Boundaries

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,0 +1,11 @@
+interface PublicLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function PublicLayout({ children }: PublicLayoutProps) {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-gradient-to-b from-background to-muted/30 p-6">
+      <div className="w-full max-w-lg">{children}</div>
+    </main>
+  );
+}

--- a/src/app/app/(admin)/admin/[...not-found]/page.tsx
+++ b/src/app/app/(admin)/admin/[...not-found]/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from "next/navigation";
+
+export default function AdminCatchAllPage() {
+  notFound();
+}

--- a/src/app/app/(admin)/admin/error.tsx
+++ b/src/app/app/(admin)/admin/error.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { ErrorState } from "@/components/feedback/error-state";
+
+interface AdminErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function AdminError({ error, reset }: AdminErrorProps) {
+  return (
+    <ErrorState
+      description="The admin section hit an unexpected problem. Retry this view or move back to another area when navigation is ready."
+      error={error}
+      reset={reset}
+      title="Admin view error"
+    />
+  );
+}

--- a/src/app/app/(admin)/admin/layout.tsx
+++ b/src/app/app/(admin)/admin/layout.tsx
@@ -1,0 +1,20 @@
+import {
+  AdminSidebarScaffold,
+  ShellTopbarScaffold,
+} from "@/components/layout/shell-scaffold";
+
+interface AdminLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function AdminLayout({ children }: AdminLayoutProps) {
+  return (
+    <div className="dark min-h-screen bg-zinc-100 lg:flex">
+      <AdminSidebarScaffold />
+      <div className="flex min-h-screen min-w-0 flex-1 flex-col bg-background text-foreground">
+        <ShellTopbarScaffold title="Admin zone" />
+        <main className="flex flex-1 flex-col p-4 sm:p-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/app/(admin)/admin/loading.tsx
+++ b/src/app/app/(admin)/admin/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingState } from "@/components/feedback/loading-state";
+
+export default function AdminLoading() {
+  return <LoadingState />;
+}

--- a/src/app/app/(admin)/admin/not-found.tsx
+++ b/src/app/app/(admin)/admin/not-found.tsx
@@ -1,0 +1,21 @@
+import { FileSearch } from "lucide-react";
+import Link from "next/link";
+
+import { EmptyState } from "@/components/feedback/empty-state";
+import { Button } from "@/components/ui/button";
+import { routes } from "@/lib/routes";
+
+export default function AdminNotFound() {
+  return (
+    <EmptyState
+      action={
+        <Button asChild>
+          <Link href={routes.adminHome}>Back to admin overview</Link>
+        </Button>
+      }
+      description="This admin page does not exist. Return to the admin overview and pick another destination."
+      icon={<FileSearch aria-hidden="true" className="size-5" />}
+      title="Admin page not found"
+    />
+  );
+}

--- a/src/app/app/(product)/[...not-found]/page.tsx
+++ b/src/app/app/(product)/[...not-found]/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from "next/navigation";
+
+export default function ProductCatchAllPage() {
+  notFound();
+}

--- a/src/app/app/(product)/error.tsx
+++ b/src/app/app/(product)/error.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { ErrorState } from "@/components/feedback/error-state";
+
+interface ProductErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function ProductError({ error, reset }: ProductErrorProps) {
+  return (
+    <ErrorState
+      description="The product view could not finish rendering. You can retry or navigate somewhere else once shared navigation ships."
+      error={error}
+      reset={reset}
+      title="Product view error"
+    />
+  );
+}

--- a/src/app/app/(product)/layout.tsx
+++ b/src/app/app/(product)/layout.tsx
@@ -1,0 +1,20 @@
+import {
+  ProductSidebarScaffold,
+  ShellTopbarScaffold,
+} from "@/components/layout/shell-scaffold";
+
+interface ProductLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function ProductLayout({ children }: ProductLayoutProps) {
+  return (
+    <div className="min-h-screen bg-muted/20 lg:flex">
+      <ProductSidebarScaffold />
+      <div className="flex min-h-screen min-w-0 flex-1 flex-col">
+        <ShellTopbarScaffold title="Product zone" />
+        <main className="flex flex-1 flex-col p-4 sm:p-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/src/app/app/(product)/loading.tsx
+++ b/src/app/app/(product)/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingState } from "@/components/feedback/loading-state";
+
+export default function ProductLoading() {
+  return <LoadingState />;
+}

--- a/src/app/app/(product)/not-found.tsx
+++ b/src/app/app/(product)/not-found.tsx
@@ -1,0 +1,21 @@
+import { FileSearch } from "lucide-react";
+import Link from "next/link";
+
+import { EmptyState } from "@/components/feedback/empty-state";
+import { Button } from "@/components/ui/button";
+import { routes } from "@/lib/routes";
+
+export default function ProductNotFound() {
+  return (
+    <EmptyState
+      action={
+        <Button asChild>
+          <Link href={routes.appHome}>Back to app home</Link>
+        </Button>
+      }
+      description="This app page is not available. Return to the product home area and choose another route."
+      icon={<FileSearch aria-hidden="true" className="size-5" />}
+      title="Page not found"
+    />
+  );
+}

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -1,0 +1,7 @@
+interface AppLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function AppLayout({ children }: AppLayoutProps) {
+  return children;
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { ErrorState } from "@/components/feedback/error-state";
+
+interface RootErrorProps {
+  error: Error & { digest?: string };
+  reset: () => void;
+}
+
+export default function RootError({ error, reset }: RootErrorProps) {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-gradient-to-b from-background to-muted/30 p-6">
+      <ErrorState
+        description="The app hit an unexpected problem while loading this page."
+        error={error}
+        reset={reset}
+      />
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 
 import "@/app/globals.css";
+import "@/lib/env";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -14,14 +15,14 @@ export const metadata: Metadata = {
   description: "Dataset-centric analytics platform",
 };
 
-type RootLayoutProps = Readonly<{
+interface RootLayoutProps {
   children: React.ReactNode;
-}>;
+}
 
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="en">
-      <body className={inter.variable}>{children}</body>
+      <body className={`${inter.variable} min-h-screen`}>{children}</body>
     </html>
   );
 }

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,9 @@
+import { LoadingState } from "@/components/feedback/loading-state";
+
+export default function Loading() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-gradient-to-b from-background to-muted/30 p-6">
+      <LoadingState />
+    </main>
+  );
+}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,23 @@
+import { FileSearch } from "lucide-react";
+import Link from "next/link";
+
+import { EmptyState } from "@/components/feedback/empty-state";
+import { Button } from "@/components/ui/button";
+import { routes } from "@/lib/routes";
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-gradient-to-b from-background to-muted/30 p-6">
+      <EmptyState
+        action={
+          <Button asChild>
+            <Link href={routes.login}>Go to login</Link>
+          </Button>
+        }
+        description="The page you requested does not exist or has moved. Start again from the login flow."
+        icon={<FileSearch aria-hidden="true" className="size-5" />}
+        title="Page not found"
+      />
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,37 +1,7 @@
-import { Badge } from "@/components/ui/badge";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { redirect } from "next/navigation";
+
+import { routes } from "@/lib/routes";
 
 export default function HomePage() {
-  return (
-    <main className="flex min-h-screen items-center justify-center bg-gradient-to-b from-background to-muted/30 p-6">
-      <Card className="w-full max-w-2xl border-border/80 shadow-black/5 shadow-lg">
-        <CardHeader className="space-y-4">
-          <Badge className="w-fit" variant="secondary">
-            Phase 1 Foundation
-          </Badge>
-          <div className="space-y-2">
-            <CardTitle className="text-3xl tracking-tight sm:text-4xl">
-              Accelerate — Phase 1 Bootstrap
-            </CardTitle>
-            <CardDescription className="max-w-prose text-base">
-              Next.js 15, React 19, TypeScript strict mode, Tailwind v4, and
-              shadcn/ui are wired up and ready for the next ticket.
-            </CardDescription>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <p className="text-muted-foreground text-sm leading-6">
-            This temporary landing page confirms the application boots and the
-            shared design tokens are loading correctly.
-          </p>
-        </CardContent>
-      </Card>
-    </main>
-  );
+  redirect(routes.login);
 }

--- a/src/components/feedback/access-denied-state.tsx
+++ b/src/components/feedback/access-denied-state.tsx
@@ -1,0 +1,28 @@
+import { ShieldAlert } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { EmptyState } from "@/components/feedback/empty-state";
+
+interface AccessDeniedStateProps {
+  action?: ReactNode;
+  className?: string;
+  description?: string;
+  title?: string;
+}
+
+export const AccessDeniedState = ({
+  action,
+  className,
+  description = "You do not have access to this area yet. If this seems wrong, contact your workspace administrator.",
+  title = "Access denied",
+}: AccessDeniedStateProps) => {
+  return (
+    <EmptyState
+      action={action}
+      className={className}
+      description={description}
+      icon={<ShieldAlert aria-hidden="true" className="size-5" />}
+      title={title}
+    />
+  );
+};

--- a/src/components/feedback/empty-state.tsx
+++ b/src/components/feedback/empty-state.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from "react";
+
+import {
+  Card,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface EmptyStateProps {
+  action?: ReactNode;
+  className?: string;
+  description: string;
+  icon?: ReactNode;
+  title: string;
+}
+
+export const EmptyState = ({
+  action,
+  className,
+  description,
+  icon,
+  title,
+}: EmptyStateProps) => {
+  return (
+    <Card
+      className={cn("w-full max-w-2xl border-border/80 shadow-sm", className)}
+    >
+      <CardHeader className="items-center space-y-4 text-center">
+        {icon ? (
+          <div className="flex size-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+            {icon}
+          </div>
+        ) : null}
+        <div className="space-y-2">
+          <CardTitle className="text-2xl tracking-tight">{title}</CardTitle>
+          <CardDescription className="mx-auto max-w-prose text-base leading-6">
+            {description}
+          </CardDescription>
+        </div>
+      </CardHeader>
+      {action ? (
+        <CardFooter className="justify-center pt-0">{action}</CardFooter>
+      ) : null}
+    </Card>
+  );
+};

--- a/src/components/feedback/error-state.tsx
+++ b/src/components/feedback/error-state.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { AlertTriangle, RotateCcw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface ErrorStateProps {
+  className?: string;
+  description?: string;
+  error?: Error & { digest?: string };
+  reset?: () => void;
+  title?: string;
+}
+
+export const ErrorState = ({
+  className,
+  description = "Something unexpected interrupted this view. Please try again.",
+  error,
+  reset,
+  title = "Something went wrong",
+}: ErrorStateProps) => {
+  const errorMessage =
+    process.env.NODE_ENV === "development" ? error?.message : undefined;
+
+  return (
+    <Card
+      className={cn("w-full max-w-2xl border-border/80 shadow-sm", className)}
+      role="alert"
+    >
+      <CardHeader className="items-center space-y-4 text-center">
+        <div className="flex size-12 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+          <AlertTriangle aria-hidden="true" className="size-5" />
+        </div>
+        <div className="space-y-2">
+          <CardTitle className="text-2xl tracking-tight">{title}</CardTitle>
+          <CardDescription className="mx-auto max-w-prose text-base leading-6">
+            {description}
+          </CardDescription>
+          {errorMessage ? (
+            <p className="rounded-md border border-destructive/20 bg-destructive/5 px-3 py-2 text-left font-mono text-destructive text-sm">
+              {errorMessage}
+            </p>
+          ) : null}
+        </div>
+      </CardHeader>
+      {reset ? (
+        <CardFooter className="justify-center pt-0">
+          <Button onClick={reset} type="button">
+            <RotateCcw aria-hidden="true" />
+            Try again
+          </Button>
+        </CardFooter>
+      ) : null}
+    </Card>
+  );
+};

--- a/src/components/feedback/loading-state.tsx
+++ b/src/components/feedback/loading-state.tsx
@@ -1,0 +1,30 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+interface LoadingStateProps {
+  className?: string;
+}
+
+export const LoadingState = ({ className }: LoadingStateProps) => {
+  return (
+    <Card
+      aria-busy="true"
+      aria-live="polite"
+      className={cn("w-full max-w-3xl border-border/80 shadow-sm", className)}
+    >
+      <CardHeader className="space-y-3">
+        <Skeleton className="h-4 w-28" />
+        <Skeleton className="h-8 w-2/3" />
+        <Skeleton className="h-4 w-1/2" />
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Skeleton className="h-32 w-full" />
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/layout/shell-scaffold.tsx
+++ b/src/components/layout/shell-scaffold.tsx
@@ -1,0 +1,119 @@
+import { LayoutDashboard, Settings2 } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+
+const productNavItems = [
+  "Home",
+  "Datasets",
+  "Workspace",
+  "Profile",
+  "Admin",
+] as const;
+
+const adminNavItems = [
+  "Overview",
+  "Users",
+  "Invites",
+  "Permissions",
+  "Datasets",
+  "APIs",
+  "Ingestion Runs",
+  "Pipeline Runs",
+  "Publishing",
+] as const;
+
+export const ProductSidebarScaffold = () => {
+  return (
+    <aside className="hidden w-72 border-r bg-background lg:flex lg:flex-col">
+      <div className="flex items-center justify-between border-b px-5 py-4">
+        <div className="flex items-center gap-3">
+          <div className="flex size-9 items-center justify-center rounded-lg bg-primary text-primary-foreground">
+            <LayoutDashboard aria-hidden="true" className="size-4" />
+          </div>
+          <div>
+            <p className="font-semibold text-sm">Accelerate</p>
+            <p className="text-muted-foreground text-xs">Product shell</p>
+          </div>
+        </div>
+        <Badge variant="secondary">T4 next</Badge>
+      </div>
+      <nav
+        aria-label="Product navigation placeholder"
+        className="flex-1 px-3 py-4"
+      >
+        <ul className="space-y-2">
+          {productNavItems.map((item) => (
+            <li
+              className="flex items-center gap-3 rounded-lg border border-border/80 border-dashed px-3 py-2 text-sm"
+              key={item}
+            >
+              <Skeleton className="size-4 rounded-full" />
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </aside>
+  );
+};
+
+export const AdminSidebarScaffold = () => {
+  return (
+    <aside className="hidden w-72 border-white/10 border-r bg-zinc-950 text-zinc-50 lg:flex lg:flex-col">
+      <div className="border-white/10 border-b px-5 py-4">
+        <Badge
+          className="mb-4 bg-zinc-800 text-zinc-100 hover:bg-zinc-800"
+          variant="secondary"
+        >
+          Admin shell
+        </Badge>
+        <div className="space-y-1">
+          <p className="font-semibold text-sm">Administration</p>
+          <p className="text-xs text-zinc-400">
+            T4 will replace this placeholder nav.
+          </p>
+        </div>
+      </div>
+      <nav
+        aria-label="Admin navigation placeholder"
+        className="flex-1 px-3 py-4"
+      >
+        <ul className="space-y-2">
+          {adminNavItems.map((item) => (
+            <li
+              className="flex items-center gap-3 rounded-lg border border-white/10 px-3 py-2 text-sm text-zinc-100"
+              key={item}
+            >
+              <Skeleton className="size-4 rounded-full bg-zinc-700" />
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </aside>
+  );
+};
+
+interface ShellTopbarScaffoldProps {
+  title: string;
+}
+
+export const ShellTopbarScaffold = ({ title }: ShellTopbarScaffoldProps) => {
+  return (
+    <header className="flex h-14 items-center justify-between border-b bg-background/95 px-4 backdrop-blur sm:px-6">
+      <div className="space-y-1">
+        <p className="font-medium text-sm tracking-tight">{title}</p>
+        <p className="text-muted-foreground text-xs">
+          Temporary shell chrome until shared navigation lands.
+        </p>
+      </div>
+      <div className="flex items-center gap-3">
+        <Badge variant="outline">Phase 1</Badge>
+        <div className="flex size-9 items-center justify-center rounded-full border bg-muted text-muted-foreground">
+          <Settings2 aria-hidden="true" className="size-4" />
+        </div>
+      </div>
+    </header>
+  );
+};

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,0 +1,22 @@
+export const routes = {
+  root: "/",
+  login: "/login",
+  invite: "/invite/[token]",
+  authCallback: "/auth/callback",
+  appHome: "/app",
+  datasets: "/app/datasets",
+  datasetDetail: "/app/datasets/[datasetId]",
+  profile: "/app/profile",
+  workspace: "/app/workspace",
+  adminHome: "/app/admin",
+  adminUsers: "/app/admin/users",
+  adminInvites: "/app/admin/invites",
+  adminPermissions: "/app/admin/permissions",
+  adminDatasets: "/app/admin/datasets",
+  adminApis: "/app/admin/apis",
+  adminIngestionRuns: "/app/admin/ingestion-runs",
+  adminPipelineRuns: "/app/admin/pipeline-runs",
+  adminPublishing: "/app/admin/publishing",
+} as const;
+
+export type AppRoute = (typeof routes)[keyof typeof routes];


### PR DESCRIPTION
## Problem
This lays out the public, product, and admin route groups and introduces the loading, empty, error, and not-found states that users will hit across those zones. Without these boundaries, the app would have no consistent shell for each area and poor handling for exceptional states.

## Root Cause
The initial scaffold had a single landing page and no route-level structure for the authenticated areas of the application.

## Fix
Add grouped app-router layouts for the public, product, and admin sections, create route-level loading and error boundaries, and introduce reusable feedback components and route constants to support those shells.

## Validation
Checks were not rerun during this PR-splitting pass. This PR preserves the original local commit unchanged.
