### PR TITLE
[codex] T5: Scaffold Placeholder Pages and Auth Callback Route

### DIFF
--- a/src/app/(public)/auth/callback/route.ts
+++ b/src/app/(public)/auth/callback/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+import { routes } from "@/lib/routes";
+
+export function GET(request: Request) {
+  return NextResponse.redirect(new URL(routes.login, request.url));
+}

--- a/src/app/(public)/invite/[token]/page.tsx
+++ b/src/app/(public)/invite/[token]/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "@/components/layout/placeholder-page";
+
+export default function InvitePage() {
+  return (
+    <PlaceholderPage
+      description="Invited users will review their invitation and complete account setup here in a later phase."
+      title="Accept Invite"
+      zone="Public"
+    />
+  );
+}

--- a/src/app/(public)/login/page.tsx
+++ b/src/app/(public)/login/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "@/components/layout/placeholder-page";
+
+export default function LoginPage() {
+  return (
+    <PlaceholderPage
+      description="Magic link authentication will let invited users sign in to the platform in Phase 2."
+      title="Login"
+      zone="Public"
+    />
+  );
+}

--- a/src/app/app/(admin)/admin/apis/page.tsx
+++ b/src/app/app/(admin)/admin/apis/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "@/components/layout/placeholder-page";
+
+export default function AdminApisPage() {
+  return (
+    <PlaceholderPage
+      description="API configuration and integration controls will be surfaced here for platform administrators."
+      title="APIs"
+      zone="Admin"
+    />
+  );
+}

--- a/src/app/app/(admin)/admin/datasets/page.tsx
+++ b/src/app/app/(admin)/admin/datasets/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "@/components/layout/placeholder-page";
+
+export default function AdminDatasetsPage() {
+  return (
+    <PlaceholderPage
+      description="Admins will govern dataset catalog configuration, visibility, and operational metadata here."
+      title="Datasets"
+      zone="Admin"
+    />
+  );
+}

--- a/src/app/app/(admin)/admin/ingestion-runs/page.tsx
+++ b/src/app/app/(admin)/admin/ingestion-runs/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "@/components/layout/placeholder-page";
+
+export default function AdminIngestionRunsPage() {
+  return (
+    <PlaceholderPage
+      description="Ingestion run history and troubleshooting details will help admins monitor data intake jobs."
+      title="Ingestion Runs"
+      zone="Admin"
+    />
+  );
+}

--- a/src/app/app/(admin)/admin/invites/page.tsx
+++ b/src/app/app/(admin)/admin/invites/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "@/components/layout/placeholder-page";
+
+export default function AdminInvitesPage() {
+  return (
+    <PlaceholderPage
+      description="Invitation workflows will let admins create, resend, and track access invitations here."
+      title="Invites"
+      zone="Admin"
+    />
+  );
+}

--- a/src/app/app/(admin)/admin/page.tsx
+++ b/src/app/app/(admin)/admin/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "@/components/layout/placeholder-page";
+
+export default function AdminOverviewPage() {
+  return (
+    <PlaceholderPage
+      description="The admin overview will summarize operational health, access posture, and platform status."
+      title="Overview"
+      zone="Admin"
+    />
+  );
+}

--- a/src/app/app/(admin)/admin/permissions/page.tsx
+++ b/src/app/app/(admin)/admin/permissions/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "@/components/layout/placeholder-page";
+
+export default function AdminPermissionsPage() {
+  return (
+    <PlaceholderPage
+      description="Role assignments and dataset access policies will be configured from the permissions console."
+      title="Permissions"
+      zone="Admin"
+    />
+  );
+}

--- a/src/app/app/(admin)/admin/pipeline-runs/page.tsx
+++ b/src/app/app/(admin)/admin/pipeline-runs/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "@/components/layout/placeholder-page";
+
+export default function AdminPipelineRunsPage() {
+  return (
+    <PlaceholderPage
+      description="Pipeline run status, diagnostics, and outcomes will be available for admin review here."
+      title="Pipeline Runs"
+      zone="Admin"
+    />
+  );
+}

--- a/src/app/app/(admin)/admin/publishing/page.tsx
+++ b/src/app/app/(admin)/admin/publishing/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "@/components/layout/placeholder-page";
+
+export default function AdminPublishingPage() {
+  return (
+    <PlaceholderPage
+      description="Publishing workflows will let administrators control releases and dataset availability."
+      title="Publishing"
+      zone="Admin"
+    />
+  );
+}

--- a/src/app/app/(admin)/admin/users/page.tsx
+++ b/src/app/app/(admin)/admin/users/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "@/components/layout/placeholder-page";
+
+export default function AdminUsersPage() {
+  return (
+    <PlaceholderPage
+      description="Administrators will manage user accounts, lifecycle changes, and membership from this page."
+      title="Users"
+      zone="Admin"
+    />
+  );
+}

--- a/src/app/app/(product)/datasets/[datasetId]/page.tsx
+++ b/src/app/app/(product)/datasets/[datasetId]/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "@/components/layout/placeholder-page";
+
+export default function DatasetDetailPage() {
+  return (
+    <PlaceholderPage
+      description="Dataset detail pages will show schema, freshness, and actions for an individual dataset."
+      title="Dataset"
+      zone="Product"
+    />
+  );
+}

--- a/src/app/app/(product)/datasets/page.tsx
+++ b/src/app/app/(product)/datasets/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "@/components/layout/placeholder-page";
+
+export default function DatasetsPage() {
+  return (
+    <PlaceholderPage
+      description="Browse and search available datasets, then drill into the records and metadata that matter."
+      title="Datasets"
+      zone="Product"
+    />
+  );
+}

--- a/src/app/app/(product)/page.tsx
+++ b/src/app/app/(product)/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "@/components/layout/placeholder-page";
+
+export default function AppHomePage() {
+  return (
+    <PlaceholderPage
+      description="This landing page will surface recent activity, shortcuts, and product guidance for signed-in users."
+      title="Home"
+      zone="Product"
+    />
+  );
+}

--- a/src/app/app/(product)/profile/page.tsx
+++ b/src/app/app/(product)/profile/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "@/components/layout/placeholder-page";
+
+export default function ProfilePage() {
+  return (
+    <PlaceholderPage
+      description="Users will manage their account details, preferences, and sign-in settings from this page."
+      title="Profile"
+      zone="Product"
+    />
+  );
+}

--- a/src/app/app/(product)/workspace/page.tsx
+++ b/src/app/app/(product)/workspace/page.tsx
@@ -1,0 +1,11 @@
+import { PlaceholderPage } from "@/components/layout/placeholder-page";
+
+export default function WorkspacePage() {
+  return (
+    <PlaceholderPage
+      description="Workspace settings and collaboration controls will live here for the core product experience."
+      title="Workspace"
+      zone="Product"
+    />
+  );
+}


### PR DESCRIPTION
## Problem
This fills in the route tree with placeholder screens and adds the public auth callback route needed to complete the basic navigation flow. Without these pages, the shared shells route into missing content and the authentication flow has no callback endpoint to land on.

## Root Cause
The layout and navigation work established the structure of the application, but most concrete route files were still absent.

## Fix
Create placeholder pages for the public, product, and admin destinations defined by the shell components, and add the auth callback route so the public auth flow has a server endpoint in place.

## Validation
Checks were not rerun during this PR-splitting pass. This PR preserves the original local commit unchanged.
