### PR TITLE
[codex] Preserve Refreshed Cookies in Supabase Middleware

### DIFF
--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -8,6 +8,8 @@ export const createClient = (request: NextRequest) => {
     request,
   });
 
+  const getResponse = (): NextResponse => response;
+
   const supabase = createServerClient(
     clientEnv.NEXT_PUBLIC_SUPABASE_URL,
     clientEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY,
@@ -21,6 +23,7 @@ export const createClient = (request: NextRequest) => {
             request.cookies.set({
               name: cookie.name,
               value: cookie.value,
+              ...cookie.options,
             });
           }
 
@@ -36,5 +39,5 @@ export const createClient = (request: NextRequest) => {
     }
   );
 
-  return { response, supabase };
+  return { getResponse, supabase };
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,8 +1,13 @@
-import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
 
-export function middleware() {
-  // Phase 2: create the Supabase middleware client here and add auth/session checks.
-  return NextResponse.next();
+import { createClient } from "@/lib/supabase/middleware";
+
+export function middleware(request: NextRequest) {
+  const middlewareClient = createClient(request);
+
+  // Phase 2: call `middlewareClient.supabase.auth.getUser()` here.
+  // Phase 2: add redirect logic here based on the authenticated user.
+  return middlewareClient.getResponse();
 }
 
 export const config = {


### PR DESCRIPTION
## Problem
This fixes a middleware bug where refreshed Supabase cookies could be dropped before the response left Next.js, which would break session persistence for users traversing protected routes.

## Root Cause
The middleware helper returned the initial `NextResponse` object even after recreating the response during cookie updates, and it did not carry the cookie options back onto the request cookie jar before rebuilding the response.

## Fix
Return a response accessor from the Supabase middleware helper, forward cookie options when mirroring cookies onto the request, and update the top-level middleware to return the latest response instance produced by the helper.

## Validation
Checks were not rerun during this PR-splitting pass. This PR preserves the original local commit unchanged.
