### PR TITLE
[codex] Restore Phase B admin operations closeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 # Server-only service role key for future admin workflows. Never expose this in the browser.
 SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 
+# Server-only Google service-account JSON for admin ingestion source reads.
+# This must be the raw JSON serialized onto one line with newline characters escaped.
+GOOGLE_SERVICE_ACCOUNT_JSON='{"client_email":"service-account@example.iam.gserviceaccount.com","private_key":"-----BEGIN PRIVATE KEY-----\\n...\\n-----END PRIVATE KEY-----\\n"}'
+
 # Public application URL.
 # Local development: http://localhost:3000
 # Vercel production: set this explicitly to https://data.accelerateglobal.org
@@ -24,6 +28,11 @@ EXPERIMENT_WAREHOUSE_CONNECTION_REFERENCE=
 EXPERIMENT_TEXT_TO_QUERY_PROVIDER=
 EXPERIMENT_TEXT_TO_QUERY_ALLOWLIST_DATASET_IDS=
 EXPERIMENT_TEXT_TO_QUERY_LOG_REFERENCE=
+
+# Optional test-only fixture controls for admin ingestion Playwright coverage.
+# Do not set these in preview or production.
+GOOGLE_SHEETS_TEST_MODE=false
+GOOGLE_SHEETS_TEST_FIXTURE_JSON=
 
 # Server-only Google Workspace service account JSON used for read-only Sheet validation.
 # Store the exact downloaded JSON document in one secret value.

--- a/docs/phase-b-production-closeout-validation.md
+++ b/docs/phase-b-production-closeout-validation.md
@@ -1,0 +1,152 @@
+# Phase B Production Closeout Validation
+
+Date: 2026-04-08
+
+This harness is for bounded Phase B hosted closeout only.
+
+It is not CI, it is not a general regression suite, and it should not introduce
+new product behavior. The current repo is the source of truth, and the harness
+now defaults to the values already present in the local untracked
+`[.env.local](/Users/blake/Documents/accelerate-global/accelerate-core/.env.local)`
+file.
+
+## Guardrails
+
+- Keep proof-only secrets outside tracked files.
+- Do not commit production passwords, keys, or hosted URLs.
+- Do not use a real collaborator account for the non-admin proof.
+- Do not repurpose the validation source for normal business workflows.
+- Do not run hosted proofs until the validation users and validation source are
+  confirmed.
+
+## Values Reused From `.env.local`
+
+The hosted closeout harness now prefers these existing repo env names first:
+
+- `NEXT_PUBLIC_APP_URL`
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `GOOGLE_WORKSPACE_SOURCE_SPREADSHEET_ID`
+- `GOOGLE_WORKSPACE_SOURCE_SHEET_NAME`
+- `GOOGLE_WORKSPACE_SOURCE_RANGE`
+
+Both the browser proof and the non-admin mutation proof load
+`[.env.local](/Users/blake/Documents/accelerate-global/accelerate-core/.env.local)`
+automatically when present.
+
+Legacy `PLAYWRIGHT_*` aliases remain fallback-only for compatibility. They are
+no longer the documented default.
+
+## Operator-Supplied Values
+
+Required:
+
+- `PHASEB_ADMIN_EMAIL`
+- `PHASEB_ADMIN_PASSWORD`
+- `PHASEB_NON_ADMIN_EMAIL`
+- `PHASEB_NON_ADMIN_PASSWORD`
+
+Optional:
+
+- `PHASEB_VALIDATION_SOURCE_SLUG`
+  Default: `phaseb-prod-validation-google-sheet`
+- `PHASEB_VALIDATION_NAMESPACE`
+  Default: `phaseb-prod-validation`
+
+Important:
+
+- `PHASEB_ADMIN_PASSWORD` and `PHASEB_NON_ADMIN_PASSWORD` are Supabase Auth
+  user passwords for the dedicated validation users.
+- They are not database passwords.
+- They are not Supabase dashboard passwords.
+
+## Values Derived In Code
+
+The harness no longer requires manual entry for these values:
+
+- `SOURCE_ID`
+  Derived by querying `registered_sources` with `PHASEB_VALIDATION_SOURCE_SLUG`
+- `RANGE`
+  Derived from `GOOGLE_WORKSPACE_SOURCE_RANGE` when present, otherwise from the
+  selected `registered_sources.config`
+- `EXPECTED_ROW_COUNT`
+  Derived from the successful `ingestion_runs.metadata` row created by the
+  browser proof run itself
+- `EXPECTED_SAMPLE_TEXT`
+  Derived from the successful `ingestion_runs.metadata.sampleRows` captured by
+  the browser proof run itself
+
+For the non-admin mutation proof, spreadsheet id, sheet name, and range are
+derived from `.env.local` first and then from the selected source config if the
+local env values are absent.
+
+## Required Hosted Validation Assets
+
+- One dedicated admin validation user with a password
+- One dedicated non-admin validation user with a password
+- One enabled `registered_sources` row addressed by
+  `PHASEB_VALIDATION_SOURCE_SLUG`
+- One dedicated validation spreadsheet shared to the production Google service
+  account already used by the hosted app
+
+## Dedicated Non-Admin Validation User
+
+The current app onboarding flow is invite-first and magic-link-based. The
+closeout proof harness, however, uses Supabase password sessions for stable
+automation.
+
+Because of that, the safest bounded way to create the dedicated non-admin proof
+user is not the in-app invite screen alone.
+
+Use a Supabase operator path instead:
+
+1. Create a dedicated Auth user in Supabase Auth with the validation email and
+   a password.
+2. Confirm the `public.profiles` row exists for that user.
+3. Confirm `public.profiles.app_role = 'user'`.
+4. Store that email/password only in local untracked env storage.
+
+Do not reuse a real collaborator account.
+
+## Exact Commands
+
+### Browser Proof
+
+Only the proof-specific admin credentials are required at runtime if
+`.env.local` already contains the shared hosted app and Supabase values.
+
+```sh
+PLAYWRIGHT_DISABLE_WEBSERVER=true \
+PHASEB_ADMIN_EMAIL="<dedicated-admin-validation-user>" \
+PHASEB_ADMIN_PASSWORD="<supabase-auth-password>" \
+./node_modules/.bin/playwright test tests/admin-operations.spec.ts --project=chromium
+```
+
+If the validation source slug is not the default, add:
+
+```sh
+PHASEB_VALIDATION_SOURCE_SLUG="<registered-source-slug>"
+```
+
+### Non-Admin Mutation Proof
+
+```sh
+PHASEB_ADMIN_EMAIL="<dedicated-admin-validation-user>" \
+PHASEB_ADMIN_PASSWORD="<supabase-auth-password>" \
+PHASEB_NON_ADMIN_EMAIL="<dedicated-non-admin-validation-user>" \
+PHASEB_NON_ADMIN_PASSWORD="<supabase-auth-password>" \
+node scripts/phaseb-nonadmin-source-create-proof.mjs
+```
+
+If the validation source slug is not the default, add:
+
+```sh
+PHASEB_VALIDATION_SOURCE_SLUG="<registered-source-slug>"
+```
+
+## Residual Data Policy
+
+- The browser proof creates one ingestion run and one deferred pipeline run.
+- Those rows are expected Phase B validation artifacts.
+- The non-admin mutation proof must leave no `registered_sources` row behind.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,8 +1,86 @@
+import { existsSync, readFileSync } from "node:fs";
+
 import { defineConfig, devices } from "@playwright/test";
+
+const envLinePattern = /\r?\n/u;
+const envNamePattern = /^[A-Za-z_][A-Za-z0-9_]*$/u;
+
+const normalizeEnvValue = (value: string): string => {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+
+  return value;
+};
+
+const parseEnvAssignment = (
+  rawLine: string
+): { value: string; variableName: string } | null => {
+  const trimmedLine = rawLine.trim();
+
+  if (!trimmedLine || trimmedLine.startsWith("#")) {
+    return null;
+  }
+
+  const separatorIndex = rawLine.indexOf("=");
+
+  if (separatorIndex <= 0) {
+    return null;
+  }
+
+  const variableName = rawLine.slice(0, separatorIndex).trim();
+
+  if (!envNamePattern.test(variableName)) {
+    return null;
+  }
+
+  return {
+    value: normalizeEnvValue(rawLine.slice(separatorIndex + 1).trim()),
+    variableName,
+  };
+};
+
+const loadLocalEnvFiles = (): void => {
+  for (const filename of [".env.local", ".env.test.local"]) {
+    if (!existsSync(filename)) {
+      continue;
+    }
+
+    const fileContents = readFileSync(filename, "utf8");
+
+    for (const rawLine of fileContents.split(envLinePattern)) {
+      const parsedAssignment = parseEnvAssignment(rawLine);
+
+      if (!parsedAssignment) {
+        continue;
+      }
+
+      if (process.env[parsedAssignment.variableName]?.trim()) {
+        continue;
+      }
+
+      process.env[parsedAssignment.variableName] = parsedAssignment.value;
+    }
+  }
+};
+
+loadLocalEnvFiles();
 
 const webServerPort = 3000;
 const webServerHost = "127.0.0.1";
 const webServerUrl = `http://${webServerHost}:${webServerPort}`;
+const disableWebServer = process.env.PLAYWRIGHT_DISABLE_WEBSERVER === "true";
+const googleSheetsFixture = JSON.stringify({
+  values: [
+    ["dataset_slug", "dataset_name", "workspace"],
+    ["phase-a-alpha", "Phase A Alpha", "Workspace A"],
+    ["phase-a-beta", "Phase A Beta", "Workspace B"],
+    ["phase-a-gamma", "Phase A Gamma", "Workspace C"],
+  ],
+});
 
 const getRequiredEnv = (name: string): string => {
   const value = process.env[name];
@@ -16,18 +94,30 @@ const getRequiredEnv = (name: string): string => {
   );
 };
 
-const localAuthEnv = {
-  NEXT_PUBLIC_APP_URL:
-    process.env.PLAYWRIGHT_NEXT_PUBLIC_APP_URL ?? webServerUrl,
-  NEXT_PUBLIC_SUPABASE_ANON_KEY:
-    process.env.PLAYWRIGHT_NEXT_PUBLIC_SUPABASE_ANON_KEY ??
-    "sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH",
-  NEXT_PUBLIC_SUPABASE_URL:
-    process.env.PLAYWRIGHT_NEXT_PUBLIC_SUPABASE_URL ?? "http://127.0.0.1:54321",
-  SUPABASE_SERVICE_ROLE_KEY: getRequiredEnv(
-    "PLAYWRIGHT_SUPABASE_SERVICE_ROLE_KEY"
-  ),
-} as const;
+const getLocalAuthEnv = () =>
+  ({
+    GOOGLE_SHEETS_TEST_FIXTURE_JSON:
+      process.env.PLAYWRIGHT_GOOGLE_SHEETS_TEST_FIXTURE_JSON ??
+      googleSheetsFixture,
+    GOOGLE_SHEETS_TEST_MODE:
+      process.env.PLAYWRIGHT_GOOGLE_SHEETS_TEST_MODE ?? "true",
+    NEXT_PUBLIC_APP_URL:
+      process.env.PLAYWRIGHT_NEXT_PUBLIC_APP_URL ?? webServerUrl,
+    NEXT_PUBLIC_SUPABASE_ANON_KEY:
+      process.env.PLAYWRIGHT_NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+      "sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH",
+    NEXT_PUBLIC_SUPABASE_URL:
+      process.env.PLAYWRIGHT_NEXT_PUBLIC_SUPABASE_URL ??
+      "http://127.0.0.1:54321",
+    SUPABASE_SERVICE_ROLE_KEY: getRequiredEnv(
+      "PLAYWRIGHT_SUPABASE_SERVICE_ROLE_KEY"
+    ),
+  }) as const;
+
+const hostedBaseUrl = process.env.NEXT_PUBLIC_APP_URL?.trim();
+const resolvedBaseUrl = disableWebServer
+  ? (hostedBaseUrl ?? process.env.PLAYWRIGHT_BASE_URL ?? webServerUrl)
+  : (process.env.PLAYWRIGHT_BASE_URL ?? webServerUrl);
 
 /**
  * Read environment variables from file.
@@ -55,7 +145,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('')`. */
-    baseURL: process.env.PLAYWRIGHT_BASE_URL ?? webServerUrl,
+    baseURL: resolvedBaseUrl,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -100,14 +190,18 @@ export default defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  webServer: {
-    command: `npm run build && npm run start -- --hostname ${webServerHost} --port ${webServerPort}`,
-    env: {
-      ...process.env,
-      ...localAuthEnv,
-      NEXT_TELEMETRY_DISABLED: "1",
-    },
-    reuseExistingServer: !process.env.CI,
-    url: process.env.PLAYWRIGHT_BASE_URL ?? webServerUrl,
-  },
+  ...(disableWebServer
+    ? {}
+    : {
+        webServer: {
+          command: `npm run build && npm run start -- --hostname ${webServerHost} --port ${webServerPort}`,
+          env: {
+            ...process.env,
+            ...getLocalAuthEnv(),
+            NEXT_TELEMETRY_DISABLED: "1",
+          },
+          reuseExistingServer: !process.env.CI,
+          url: resolvedBaseUrl,
+        },
+      }),
 });

--- a/scripts/phaseb-nonadmin-source-create-proof.mjs
+++ b/scripts/phaseb-nonadmin-source-create-proof.mjs
@@ -1,0 +1,393 @@
+import { existsSync, readFileSync } from "node:fs";
+
+import { createClient } from "@supabase/supabase-js";
+import { chromium } from "playwright";
+
+const defaultValidationNamespace = "phaseb-prod-validation";
+const defaultValidationSourceSlug = "phaseb-prod-validation-google-sheet";
+const envLinePattern = /\r?\n/u;
+const envNamePattern = /^[A-Za-z_][A-Za-z0-9_]*$/u;
+
+const normalizeEnvValue = (value) => {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+
+  return value;
+};
+
+const parseEnvAssignment = (rawLine) => {
+  const trimmedLine = rawLine.trim();
+
+  if (!trimmedLine || trimmedLine.startsWith("#")) {
+    return null;
+  }
+
+  const separatorIndex = rawLine.indexOf("=");
+
+  if (separatorIndex <= 0) {
+    return null;
+  }
+
+  const variableName = rawLine.slice(0, separatorIndex).trim();
+
+  if (!envNamePattern.test(variableName)) {
+    return null;
+  }
+
+  return {
+    value: normalizeEnvValue(rawLine.slice(separatorIndex + 1).trim()),
+    variableName,
+  };
+};
+
+const loadLocalEnvFiles = () => {
+  for (const filename of [".env.local", ".env.test.local"]) {
+    if (!existsSync(filename)) {
+      continue;
+    }
+
+    const fileContents = readFileSync(filename, "utf8");
+
+    for (const rawLine of fileContents.split(envLinePattern)) {
+      const parsedAssignment = parseEnvAssignment(rawLine);
+
+      if (!parsedAssignment) {
+        continue;
+      }
+
+      if (process.env[parsedAssignment.variableName]?.trim()) {
+        continue;
+      }
+
+      process.env[parsedAssignment.variableName] = parsedAssignment.value;
+    }
+  }
+};
+
+loadLocalEnvFiles();
+
+const getFirstDefinedEnvValue = (...names) => {
+  for (const name of names) {
+    const value = process.env[name]?.trim();
+
+    if (value) {
+      return value;
+    }
+  }
+
+  return undefined;
+};
+
+const requireEnv = (label, ...envNames) => {
+  const value = getFirstDefinedEnvValue(...envNames);
+
+  if (!value) {
+    throw new Error(`${label} is required for Phase B production validation.`);
+  }
+
+  return value;
+};
+
+const getOptionalEnv = (...envNames) => {
+  return getFirstDefinedEnvValue(...envNames);
+};
+
+const appUrl = requireEnv(
+  "NEXT_PUBLIC_APP_URL",
+  "NEXT_PUBLIC_APP_URL",
+  "PHASEB_APP_URL"
+);
+const supabaseUrl = requireEnv(
+  "NEXT_PUBLIC_SUPABASE_URL",
+  "NEXT_PUBLIC_SUPABASE_URL"
+);
+const supabaseAnonKey = requireEnv(
+  "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+  "NEXT_PUBLIC_SUPABASE_ANON_KEY"
+);
+const supabaseServiceRoleKey = requireEnv(
+  "SUPABASE_SERVICE_ROLE_KEY",
+  "SUPABASE_SERVICE_ROLE_KEY"
+);
+const validationNamespace =
+  getOptionalEnv("PHASEB_VALIDATION_NAMESPACE") ?? defaultValidationNamespace;
+const validationSourceSlug =
+  getOptionalEnv("PHASEB_VALIDATION_SOURCE_SLUG") ??
+  defaultValidationSourceSlug;
+
+const adminCredentials = {
+  email: requireEnv("PHASEB_ADMIN_EMAIL", "PHASEB_ADMIN_EMAIL"),
+  password: requireEnv("PHASEB_ADMIN_PASSWORD", "PHASEB_ADMIN_PASSWORD"),
+};
+const nonAdminCredentials = {
+  email: requireEnv("PHASEB_NON_ADMIN_EMAIL", "PHASEB_NON_ADMIN_EMAIL"),
+  password: requireEnv(
+    "PHASEB_NON_ADMIN_PASSWORD",
+    "PHASEB_NON_ADMIN_PASSWORD"
+  ),
+};
+
+const sourceName = `${validationNamespace}-source-create-attempt-${Date.now()}`;
+
+const serviceClient = createClient(supabaseUrl, supabaseServiceRoleKey, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false,
+  },
+});
+
+const toBase64Url = (input) => {
+  return Buffer.from(input)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+};
+
+const getPasswordSession = async (credentials) => {
+  const response = await fetch(
+    `${supabaseUrl}/auth/v1/token?grant_type=password`,
+    {
+      body: JSON.stringify(credentials),
+      headers: {
+        apikey: supabaseAnonKey,
+        "content-type": "application/json",
+      },
+      method: "POST",
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Auth failed for ${credentials.email}: ${response.status} ${response.statusText}`
+    );
+  }
+
+  return response.json();
+};
+
+const buildSessionCookieValue = (session) => {
+  const payload = {
+    access_token: session.access_token,
+    expires_at: session.expires_at,
+    expires_in: session.expires_in,
+    refresh_token: session.refresh_token,
+    token_type: session.token_type,
+    user: session.user,
+  };
+
+  return `base64-${toBase64Url(JSON.stringify(payload))}`;
+};
+
+const getSupabaseSessionCookieName = (url) => {
+  const hostname = new URL(url).hostname;
+  const storageKeySegment = hostname.split(".")[0];
+
+  if (!storageKeySegment) {
+    throw new Error("Could not derive the Supabase auth cookie name.");
+  }
+
+  return `sb-${storageKeySegment}-auth-token`;
+};
+
+const createBrowserContextForSession = async (browser, session) => {
+  const context = await browser.newContext();
+
+  await context.addCookies([
+    {
+      httpOnly: false,
+      name: getSupabaseSessionCookieName(supabaseUrl),
+      sameSite: "Lax",
+      url: appUrl,
+      value: buildSessionCookieValue(session),
+    },
+  ]);
+
+  return context;
+};
+
+const isRecord = (value) => {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+};
+
+const getConfigString = (value, key) => {
+  if (!isRecord(value) || typeof value[key] !== "string") {
+    return null;
+  }
+
+  const normalizedValue = value[key].trim();
+
+  return normalizedValue || null;
+};
+
+const resolveValidationSourceValues = async () => {
+  const { data, error } = await serviceClient
+    .from("registered_sources")
+    .select("id, slug, name, config")
+    .eq("slug", validationSourceSlug)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load validation source: ${error.message}`);
+  }
+
+  if (!data) {
+    throw new Error(
+      `Validation source slug "${validationSourceSlug}" was not found.`
+    );
+  }
+
+  const spreadsheetId =
+    getOptionalEnv("GOOGLE_WORKSPACE_SOURCE_SPREADSHEET_ID") ??
+    getConfigString(data.config, "spreadsheetId");
+  const sheetName =
+    getOptionalEnv("GOOGLE_WORKSPACE_SOURCE_SHEET_NAME") ??
+    getConfigString(data.config, "sheetName");
+  const range =
+    getOptionalEnv("GOOGLE_WORKSPACE_SOURCE_RANGE") ??
+    getConfigString(data.config, "range");
+
+  if (!(spreadsheetId && sheetName && range)) {
+    throw new Error(
+      "Validation spreadsheet id, sheet name, and range must come from .env.local or the registered source config."
+    );
+  }
+
+  return {
+    range,
+    sheetName,
+    sourceId: data.id,
+    sourceSlug: data.slug,
+    spreadsheetId,
+  };
+};
+
+const extractCreateSourceActionPayload = async (
+  adminPage,
+  validationSourceValues
+) => {
+  await adminPage.goto(`${appUrl}/app/admin/ingestion-runs`, {
+    waitUntil: "networkidle",
+  });
+
+  const actionForm = adminPage
+    .locator("form")
+    .filter({
+      has: adminPage.locator(
+        'input[name="connectorKind"][value="google_sheets"]'
+      ),
+    })
+    .first();
+
+  if ((await actionForm.count()) === 0) {
+    throw new Error("Could not locate source creation form.");
+  }
+
+  return actionForm.evaluate(
+    (form, values) => {
+      const action = form.getAttribute("action") ?? window.location.pathname;
+      const payload = new FormData(form);
+
+      payload.set("name", values.sourceName);
+      payload.set(
+        "description",
+        "Phase B production validation only. Non-admin mutation proof attempt."
+      );
+      payload.set("spreadsheetId", values.validationSpreadsheetId);
+      payload.set("sheetName", values.validationSheetName);
+      payload.set("range", values.validationRange);
+      payload.set("isEnabled", "true");
+
+      return {
+        action,
+        entries: Object.fromEntries(
+          Array.from(payload.entries()).map(([key, value]) => [
+            key,
+            String(value),
+          ])
+        ),
+      };
+    },
+    {
+      sourceName,
+      validationRange: validationSourceValues.range,
+      validationSheetName: validationSourceValues.sheetName,
+      validationSpreadsheetId: validationSourceValues.spreadsheetId,
+    }
+  );
+};
+
+const sourceExists = async () => {
+  const { data, error } = await serviceClient
+    .from("registered_sources")
+    .select("id")
+    .eq("name", sourceName)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to inspect registered_sources: ${error.message}`);
+  }
+
+  return Boolean(data);
+};
+
+const main = async () => {
+  const browser = await chromium.launch({ headless: true });
+  const adminSession = await getPasswordSession(adminCredentials);
+  const nonAdminSession = await getPasswordSession(nonAdminCredentials);
+  const adminContext = await createBrowserContextForSession(
+    browser,
+    adminSession
+  );
+  const nonAdminContext = await createBrowserContextForSession(
+    browser,
+    nonAdminSession
+  );
+  const adminPage = await adminContext.newPage();
+  const validationSourceValues = await resolveValidationSourceValues();
+  const payload = await extractCreateSourceActionPayload(
+    adminPage,
+    validationSourceValues
+  );
+  const mutationResponse = await nonAdminContext.request.post(
+    `${appUrl}${payload.action}`,
+    {
+      failOnStatusCode: false,
+      form: payload.entries,
+    }
+  );
+  const blocked = !(await sourceExists());
+
+  console.log(
+    JSON.stringify(
+      {
+        attemptedSourceName: sourceName,
+        mutationBlocked: blocked,
+        mutationFinalUrl: mutationResponse.url(),
+        mutationStatus: mutationResponse.status(),
+        representativeMutation: "saveRegisteredSourceAction",
+        validationNamespace,
+        validationSourceId: validationSourceValues.sourceId,
+        validationSourceSlug: validationSourceValues.sourceSlug,
+      },
+      null,
+      2
+    )
+  );
+
+  await adminContext.close();
+  await nonAdminContext.close();
+  await browser.close();
+
+  if (!blocked) {
+    throw new Error(
+      "Non-admin source creation attempt inserted a registered source. Admin guard proof failed."
+    );
+  }
+};
+
+await main();

--- a/src/app/app/(admin)/admin/ingestion-runs/page.tsx
+++ b/src/app/app/(admin)/admin/ingestion-runs/page.tsx
@@ -1,8 +1,14 @@
-import { AdminOversightPageView } from "@/features/admin/operations/page";
-import { loadAdminOversightPage } from "@/features/admin/operations/server";
+import { AdminIngestionRunsPageView } from "@/features/admin/operations/page";
+import { loadAdminIngestionRunsPage } from "@/features/admin/operations/server";
 
-export default async function AdminIngestionRunsPage() {
-  const pageData = await loadAdminOversightPage("ingestion-runs");
+interface AdminIngestionRunsPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
 
-  return <AdminOversightPageView {...pageData} />;
+export default async function AdminIngestionRunsPage({
+  searchParams,
+}: AdminIngestionRunsPageProps) {
+  const pageData = await loadAdminIngestionRunsPage(await searchParams);
+
+  return <AdminIngestionRunsPageView {...pageData} />;
 }

--- a/src/app/app/(admin)/admin/pipeline-runs/page.tsx
+++ b/src/app/app/(admin)/admin/pipeline-runs/page.tsx
@@ -1,8 +1,14 @@
-import { AdminOversightPageView } from "@/features/admin/operations/page";
-import { loadAdminOversightPage } from "@/features/admin/operations/server";
+import { AdminPipelineRunsPageView } from "@/features/admin/operations/page";
+import { loadAdminPipelineRunsPage } from "@/features/admin/operations/server";
 
-export default async function AdminPipelineRunsPage() {
-  const pageData = await loadAdminOversightPage("pipeline-runs");
+interface AdminPipelineRunsPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
 
-  return <AdminOversightPageView {...pageData} />;
+export default async function AdminPipelineRunsPage({
+  searchParams,
+}: AdminPipelineRunsPageProps) {
+  const pageData = await loadAdminPipelineRunsPage(await searchParams);
+
+  return <AdminPipelineRunsPageView {...pageData} />;
 }

--- a/src/features/admin/datasets/actions.ts
+++ b/src/features/admin/datasets/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 
+import { publishRunActionType } from "@/features/admin/operations/source-config";
 import { requireCurrentUserAdmin } from "@/lib/auth/server";
 import { routes } from "@/lib/routes";
 import { createAdminClient } from "@/lib/supabase/admin";
@@ -224,15 +225,83 @@ export const activateDatasetVersionAction = async (
   }
 
   const supabase = createAdminClient();
-  const { error } = await supabase.rpc("activate_dataset_version", {
+  const startedAt = new Date().toISOString();
+  const { data: publishRun, error: createPublishRunError } = await supabase
+    .from("publish_runs")
+    .insert({
+      action_type: publishRunActionType.activateDatasetVersion,
+      dataset_id: datasetId,
+      dataset_version_id: datasetVersionId,
+      metadata: {},
+      requested_by: actingUser.id,
+      started_at: startedAt,
+      status: "running",
+    })
+    .select("id")
+    .single();
+
+  if (createPublishRunError) {
+    throw new Error(
+      toErrorMessage(
+        "Failed to create the publishing operation record",
+        createPublishRunError.message
+      )
+    );
+  }
+
+  const { data, error } = await supabase.rpc("activate_dataset_version", {
     target_actor_user_id: actingUser.id,
     target_dataset_id: datasetId,
     target_dataset_version_id: datasetVersionId,
   });
 
   if (error) {
+    const { error: publishRunError } = await supabase
+      .from("publish_runs")
+      .update({
+        completed_at: new Date().toISOString(),
+        error_message: error.message,
+        status: "failed",
+      })
+      .eq("id", publishRun.id);
+
+    if (publishRunError) {
+      throw new Error(
+        toErrorMessage(
+          "Failed to mark the publishing operation as failed",
+          publishRunError.message
+        )
+      );
+    }
+
     throw new Error(
       toErrorMessage("Failed to activate the dataset version", error.message)
+    );
+  }
+
+  const { error: publishRunError } = await supabase
+    .from("publish_runs")
+    .update({
+      completed_at: new Date().toISOString(),
+      error_message: null,
+      metadata: {
+        existingDomainHistoryTable: "dataset_version_events",
+        operationWrapper: true,
+        rpcResult:
+          typeof data === "object" && data !== null && !Array.isArray(data)
+            ? data
+            : {},
+      },
+      status: "succeeded",
+    })
+    .eq("id", publishRun.id);
+
+  if (publishRunError) {
+    throw new Error(
+      toErrorMessage(
+        "Failed to complete the publishing operation record",
+        publishRunError.message
+      )
     );
   }
 

--- a/src/features/admin/index.ts
+++ b/src/features/admin/index.ts
@@ -1,6 +1,6 @@
 export const adminFeatureStatus = {
-  phase: "Phase 6",
+  phase: "Phase B",
   status: "implemented",
   summary:
-    "Administrative users, invites, permissions, datasets, and publishing are implemented. API and run oversight remain bounded placeholders until real backing systems are provided.",
+    "Administrative users, invites, permissions, datasets, publishing, and bounded ingestion operations are implemented. API readiness remains scaffolded, while pipeline runs stay explicitly deferred scaffolding only.",
 } as const;

--- a/src/features/admin/operations/actions.ts
+++ b/src/features/admin/operations/actions.ts
@@ -1,0 +1,561 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+
+import {
+  type AdminActionState,
+  createInitialAdminActionState,
+} from "@/features/admin/shared";
+import { normalizeJsonRecord } from "@/features/datasets/types";
+import { requireCurrentUserAdmin } from "@/lib/auth/server";
+import { routes } from "@/lib/routes";
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { Json, Tables } from "@/lib/supabase/database.types";
+
+import { readGoogleSheetValues } from "./google-sheets";
+import {
+  ingestionRunKind,
+  parseGoogleSheetsSourceConfig,
+  pipelineExecutionMode,
+  pipelineKey,
+  registeredSourceConnectorKind,
+  registeredSourceFormSchema,
+  sourceReadBounds,
+} from "./source-config";
+
+const toErrorMessage = (message: string, cause?: string): string => {
+  if (!cause) {
+    return message;
+  }
+
+  return `${message}: ${cause}`;
+};
+
+const getIngestionRunsHref = (sourceId?: string, runId?: string): string => {
+  const params = new URLSearchParams();
+
+  if (sourceId) {
+    params.set("sourceId", sourceId);
+  }
+
+  if (runId) {
+    params.set("runId", runId);
+  }
+
+  const query = params.toString();
+
+  return query
+    ? `${routes.adminIngestionRuns}?${query}`
+    : routes.adminIngestionRuns;
+};
+
+const revalidateOperationsPaths = (): void => {
+  revalidatePath(routes.adminHome);
+  revalidatePath(routes.adminIngestionRuns);
+  revalidatePath(routes.adminPipelineRuns);
+  revalidatePath(routes.adminPublishing);
+};
+
+const createBaseSlug = (value: string): string => {
+  const normalizedSlug = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48);
+
+  return normalizedSlug || "source";
+};
+
+const createUniqueSourceSlug = async (name: string): Promise<string> => {
+  const supabase = createAdminClient();
+  const baseSlug = createBaseSlug(name);
+  let nextSlug = baseSlug;
+  let suffix = 2;
+
+  for (;;) {
+    const { data, error } = await supabase
+      .from("registered_sources")
+      .select("id")
+      .eq("slug", nextSlug)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(
+        toErrorMessage("Failed to inspect existing source slugs", error.message)
+      );
+    }
+
+    if (!data) {
+      return nextSlug;
+    }
+
+    nextSlug = `${baseSlug}-${suffix}`;
+    suffix += 1;
+  }
+};
+
+const truncateStoredCell = (
+  value: string
+): { value: string; wasTruncated: boolean } => {
+  if (value.length <= sourceReadBounds.maxStoredCellLength) {
+    return {
+      value,
+      wasTruncated: false,
+    };
+  }
+
+  return {
+    value: `${value.slice(0, sourceReadBounds.maxStoredCellLength - 1)}...`,
+    wasTruncated: true,
+  };
+};
+
+const buildSourceConfigSnapshot = (
+  source: Pick<Tables<"registered_sources">, "config" | "connector_kind">
+): Record<string, Json> => {
+  return {
+    ...normalizeJsonRecord(source.config),
+    connectorKind: source.connector_kind,
+  };
+};
+
+const buildIngestionRunMetadata = (
+  values: string[][],
+  durationMs: number,
+  valuesSource: "google_api" | "test_fixture"
+) => {
+  const rawRowCount = values.length;
+  const fullColumnCount = values.reduce((maxColumnCount, row) => {
+    return Math.max(maxColumnCount, row.length);
+  }, 0);
+  const storedColumnCount = Math.min(
+    fullColumnCount,
+    sourceReadBounds.maxHeaderCount
+  );
+  const dataRowCount = Math.max(rawRowCount - 1, 0);
+  let cellValuesTruncated = false;
+
+  const headers = (values[0] ?? [])
+    .slice(0, storedColumnCount)
+    .map((value, index) => {
+      const truncatedValue = truncateStoredCell(value.trim());
+
+      if (truncatedValue.wasTruncated) {
+        cellValuesTruncated = true;
+      }
+
+      return truncatedValue.value || `Column ${index + 1}`;
+    });
+
+  let sampleRows = values
+    .slice(1, sourceReadBounds.maxSampleRows + 1)
+    .map((row) => {
+      return row.slice(0, storedColumnCount).map((value) => {
+        const truncatedValue = truncateStoredCell(value);
+
+        if (truncatedValue.wasTruncated) {
+          cellValuesTruncated = true;
+        }
+
+        return truncatedValue.value;
+      });
+    });
+  let metadataTruncated = false;
+  const headersTruncated = fullColumnCount > headers.length;
+  const sampleRowsTruncated = dataRowCount > sampleRows.length;
+
+  let metadata = {
+    columnCount: fullColumnCount,
+    connectorDurationMs: Math.max(0, Math.round(durationMs)),
+    dataRowCount,
+    headers,
+    metadataBytes: 0,
+    rawRowCount,
+    sampleRows,
+    truncated: {
+      cellValues: cellValuesTruncated,
+      headers: headersTruncated,
+      metadata: false,
+      sampleRows: sampleRowsTruncated,
+    },
+    valuesSource,
+  };
+
+  let metadataBytes = Buffer.byteLength(JSON.stringify(metadata), "utf8");
+
+  while (
+    metadataBytes > sourceReadBounds.maxMetadataBytes &&
+    sampleRows.length > 0
+  ) {
+    sampleRows = sampleRows.slice(0, -1);
+    metadataTruncated = true;
+    metadata = {
+      ...metadata,
+      sampleRows,
+      truncated: {
+        ...metadata.truncated,
+        metadata: true,
+        sampleRows: true,
+      },
+    };
+    metadataBytes = Buffer.byteLength(JSON.stringify(metadata), "utf8");
+  }
+
+  return {
+    ...metadata,
+    metadataBytes,
+    truncated: {
+      ...metadata.truncated,
+      metadata: metadataTruncated,
+    },
+  };
+};
+
+const createDeferredPipelineRun = async ({
+  actingUserId,
+  ingestionRunId,
+  metadata,
+  source,
+}: {
+  actingUserId: string;
+  ingestionRunId: string;
+  metadata: {
+    columnCount: number;
+    dataRowCount: number;
+    valuesSource: "google_api" | "test_fixture";
+  };
+  source: Pick<Tables<"registered_sources">, "id">;
+}): Promise<string> => {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("pipeline_runs")
+    .insert({
+      execution_mode: pipelineExecutionMode.deferredScaffold,
+      ingestion_run_id: ingestionRunId,
+      metadata: {
+        deferred: true,
+        executionMode: pipelineExecutionMode.deferredScaffold,
+        ingestionRunId,
+        reason:
+          "Phase B stores durable downstream placeholders only. No pipeline execution is implemented yet.",
+        sourceReadSummary: metadata,
+      },
+      pipeline_key: pipelineKey.sourceIngestionScaffold,
+      requested_by: actingUserId,
+      source_id: source.id,
+      status: "queued",
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    throw new Error(
+      toErrorMessage(
+        "Failed to create the deferred pipeline run",
+        error.message
+      )
+    );
+  }
+
+  return data.id;
+};
+
+export const saveRegisteredSourceAction = async (
+  _previousState: AdminActionState<{ sourceId: string }>,
+  formData: FormData
+): Promise<AdminActionState<{ sourceId: string }>> => {
+  const initialState = createInitialAdminActionState<{ sourceId: string }>();
+  const actingUser = await requireCurrentUserAdmin();
+  const parsedForm = registeredSourceFormSchema.safeParse({
+    connectorKind: formData.get("connectorKind"),
+    description: formData.get("description"),
+    isEnabled: formData.get("isEnabled") === "true",
+    name: formData.get("name"),
+    range: formData.get("range"),
+    sheetName: formData.get("sheetName"),
+    sourceId: formData.get("sourceId"),
+    spreadsheetId: formData.get("spreadsheetId"),
+  });
+
+  if (!parsedForm.success) {
+    return {
+      ...initialState,
+      message:
+        parsedForm.error.issues[0]?.message ?? "Source details are invalid.",
+      status: "error",
+    };
+  }
+
+  const supabase = createAdminClient();
+  const payload = {
+    config: {
+      range: parsedForm.data.range,
+      sheetName: parsedForm.data.sheetName,
+      spreadsheetId: parsedForm.data.spreadsheetId,
+    },
+    connector_kind: registeredSourceConnectorKind.googleSheets,
+    description: parsedForm.data.description,
+    is_enabled: parsedForm.data.isEnabled,
+    name: parsedForm.data.name,
+  } as const;
+
+  if (parsedForm.data.sourceId) {
+    const { error } = await supabase
+      .from("registered_sources")
+      .update(payload)
+      .eq("id", parsedForm.data.sourceId);
+
+    if (error) {
+      return {
+        ...initialState,
+        message: toErrorMessage("Failed to update the source", error.message),
+        status: "error",
+      };
+    }
+
+    revalidateOperationsPaths();
+    redirect(getIngestionRunsHref(parsedForm.data.sourceId));
+  }
+
+  const slug = await createUniqueSourceSlug(parsedForm.data.name);
+  const { data, error } = await supabase
+    .from("registered_sources")
+    .insert({
+      ...payload,
+      created_by: actingUser.id,
+      slug,
+    })
+    .select("id")
+    .single();
+
+  if (error) {
+    return {
+      ...initialState,
+      message: toErrorMessage("Failed to create the source", error.message),
+      status: "error",
+    };
+  }
+
+  revalidateOperationsPaths();
+  redirect(getIngestionRunsHref(data.id));
+};
+
+export const toggleRegisteredSourceEnabledAction = async (
+  formData: FormData
+): Promise<void> => {
+  await requireCurrentUserAdmin();
+  const sourceId = formData.get("sourceId");
+  const nextEnabled = formData.get("nextEnabled");
+
+  if (typeof sourceId !== "string" || !sourceId) {
+    throw new Error("A source id is required.");
+  }
+
+  if (nextEnabled !== "true" && nextEnabled !== "false") {
+    throw new Error("A valid source enabled state is required.");
+  }
+
+  const supabase = createAdminClient();
+  const { error } = await supabase
+    .from("registered_sources")
+    .update({
+      is_enabled: nextEnabled === "true",
+    })
+    .eq("id", sourceId);
+
+  if (error) {
+    throw new Error(
+      toErrorMessage("Failed to update the source state", error.message)
+    );
+  }
+
+  revalidateOperationsPaths();
+  redirect(getIngestionRunsHref(sourceId));
+};
+
+export const triggerRegisteredSourceReadAction = async (
+  formData: FormData
+): Promise<void> => {
+  const actingUser = await requireCurrentUserAdmin();
+  const sourceId = formData.get("sourceId");
+
+  if (typeof sourceId !== "string" || !sourceId) {
+    throw new Error("A source id is required.");
+  }
+
+  const supabase = createAdminClient();
+  const { data: source, error: sourceError } = await supabase
+    .from("registered_sources")
+    .select(
+      "id, slug, name, connector_kind, is_enabled, config, last_run_at, last_run_status"
+    )
+    .eq("id", sourceId)
+    .maybeSingle();
+
+  if (sourceError) {
+    throw new Error(
+      toErrorMessage("Failed to load the source", sourceError.message)
+    );
+  }
+
+  if (!source) {
+    throw new Error("The selected source could not be found.");
+  }
+
+  if (!source.is_enabled) {
+    throw new Error("Disabled sources cannot be triggered.");
+  }
+
+  const sourceConfigSnapshot = buildSourceConfigSnapshot(source);
+  const { data: createdRun, error: createRunError } = await supabase
+    .from("ingestion_runs")
+    .insert({
+      metadata: {},
+      requested_by: actingUser.id,
+      run_kind: ingestionRunKind.sourceRead,
+      source_config_snapshot: sourceConfigSnapshot,
+      source_id: source.id,
+      status: "queued",
+    })
+    .select("id")
+    .single();
+
+  if (createRunError) {
+    throw new Error(
+      toErrorMessage(
+        "Failed to create the ingestion run",
+        createRunError.message
+      )
+    );
+  }
+
+  const runId = createdRun.id;
+  const startedAt = new Date().toISOString();
+
+  const markRunFailed = async (message: string): Promise<void> => {
+    const completedAt = new Date().toISOString();
+    const { error: runUpdateError } = await supabase
+      .from("ingestion_runs")
+      .update({
+        completed_at: completedAt,
+        error_message: message,
+        started_at: startedAt,
+        status: "failed",
+      })
+      .eq("id", runId);
+
+    if (runUpdateError) {
+      throw new Error(
+        toErrorMessage(
+          "Failed to mark the ingestion run as failed",
+          runUpdateError.message
+        )
+      );
+    }
+
+    const { error: sourceUpdateError } = await supabase
+      .from("registered_sources")
+      .update({
+        last_run_at: completedAt,
+        last_run_status: "failed",
+      })
+      .eq("id", source.id);
+
+    if (sourceUpdateError) {
+      throw new Error(
+        toErrorMessage(
+          "Failed to update source run status",
+          sourceUpdateError.message
+        )
+      );
+    }
+  };
+
+  const { error: runningError } = await supabase
+    .from("ingestion_runs")
+    .update({
+      started_at: startedAt,
+      status: "running",
+    })
+    .eq("id", runId);
+
+  if (runningError) {
+    throw new Error(
+      toErrorMessage("Failed to start the ingestion run", runningError.message)
+    );
+  }
+
+  try {
+    const sourceConfig = parseGoogleSheetsSourceConfig(source.config);
+
+    if (!sourceConfig) {
+      throw new Error("The registered source configuration is invalid.");
+    }
+
+    const readResult = await readGoogleSheetValues(sourceConfig);
+    const metadata = buildIngestionRunMetadata(
+      readResult.values,
+      readResult.durationMs,
+      readResult.valuesSource
+    );
+    const completedAt = new Date().toISOString();
+    const { error: completeRunError } = await supabase
+      .from("ingestion_runs")
+      .update({
+        completed_at: completedAt,
+        error_message: null,
+        metadata,
+        started_at: startedAt,
+        status: "succeeded",
+      })
+      .eq("id", runId);
+
+    if (completeRunError) {
+      throw new Error(
+        toErrorMessage(
+          "Failed to complete the ingestion run",
+          completeRunError.message
+        )
+      );
+    }
+
+    const { error: sourceUpdateError } = await supabase
+      .from("registered_sources")
+      .update({
+        last_run_at: completedAt,
+        last_run_status: "succeeded",
+      })
+      .eq("id", source.id);
+
+    if (sourceUpdateError) {
+      throw new Error(
+        toErrorMessage(
+          "Failed to update source run status",
+          sourceUpdateError.message
+        )
+      );
+    }
+
+    await createDeferredPipelineRun({
+      actingUserId: actingUser.id,
+      ingestionRunId: runId,
+      metadata: {
+        columnCount: metadata.columnCount,
+        dataRowCount: metadata.dataRowCount,
+        valuesSource: metadata.valuesSource,
+      },
+      source,
+    });
+  } catch (error) {
+    await markRunFailed(
+      error instanceof Error
+        ? error.message
+        : "An unexpected source-read error occurred."
+    );
+  }
+
+  revalidateOperationsPaths();
+  redirect(getIngestionRunsHref(source.id, runId));
+};

--- a/src/features/admin/operations/google-sheets.ts
+++ b/src/features/admin/operations/google-sheets.ts
@@ -1,0 +1,197 @@
+import "server-only";
+
+import { createSign } from "node:crypto";
+
+import { z } from "zod";
+
+import { getGoogleServiceAccountJson } from "@/lib/env";
+
+import type { GoogleSheetsSourceConfig } from "./source-config";
+import { buildGoogleSheetsValueRange } from "./source-config";
+
+const googleSheetsScope =
+  "https://www.googleapis.com/auth/spreadsheets.readonly";
+const defaultGoogleTokenUri = "https://oauth2.googleapis.com/token";
+
+const googleServiceAccountSchema = z.object({
+  client_email: z.string().trim().email(),
+  private_key: z.string().trim().min(1),
+  token_uri: z.string().trim().url().default(defaultGoogleTokenUri),
+});
+
+const googleSheetsFixtureSchema = z.object({
+  values: z.array(z.array(z.string())).default([]),
+});
+
+interface GoogleServiceAccount {
+  clientEmail: string;
+  privateKey: string;
+  tokenUri: string;
+}
+
+export interface GoogleSheetsReadResult {
+  durationMs: number;
+  values: string[][];
+  valuesSource: "google_api" | "test_fixture";
+}
+
+const toBase64Url = (value: Buffer | string): string => {
+  return Buffer.from(value)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+};
+
+const getGoogleServiceAccount = (): GoogleServiceAccount => {
+  const rawValue = getGoogleServiceAccountJson();
+  let parsedJson: unknown;
+
+  try {
+    parsedJson = JSON.parse(rawValue);
+  } catch {
+    throw new Error("GOOGLE_SERVICE_ACCOUNT_JSON must be valid JSON.");
+  }
+
+  const parsedAccount = googleServiceAccountSchema.safeParse(parsedJson);
+
+  if (!parsedAccount.success) {
+    throw new Error("GOOGLE_SERVICE_ACCOUNT_JSON is missing required fields.");
+  }
+
+  return {
+    clientEmail: parsedAccount.data.client_email,
+    privateKey: parsedAccount.data.private_key,
+    tokenUri: parsedAccount.data.token_uri,
+  };
+};
+
+const getTestFixtureValues = (): string[][] | null => {
+  if (process.env.GOOGLE_SHEETS_TEST_MODE !== "true") {
+    return null;
+  }
+
+  const rawFixture = process.env.GOOGLE_SHEETS_TEST_FIXTURE_JSON?.trim();
+
+  if (!rawFixture) {
+    throw new Error(
+      "GOOGLE_SHEETS_TEST_FIXTURE_JSON is required when GOOGLE_SHEETS_TEST_MODE=true."
+    );
+  }
+
+  let parsedFixture: unknown;
+
+  try {
+    parsedFixture = JSON.parse(rawFixture);
+  } catch {
+    throw new Error("GOOGLE_SHEETS_TEST_FIXTURE_JSON must be valid JSON.");
+  }
+
+  const fixture = googleSheetsFixtureSchema.safeParse(parsedFixture);
+
+  if (!fixture.success) {
+    throw new Error(
+      "GOOGLE_SHEETS_TEST_FIXTURE_JSON must match the expected values shape."
+    );
+  }
+
+  return fixture.data.values;
+};
+
+const buildSignedJwt = (serviceAccount: GoogleServiceAccount): string => {
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const header = {
+    alg: "RS256",
+    typ: "JWT",
+  };
+  const claims = {
+    aud: serviceAccount.tokenUri,
+    exp: issuedAt + 3600,
+    iat: issuedAt,
+    iss: serviceAccount.clientEmail,
+    scope: googleSheetsScope,
+  };
+  const unsignedToken = `${toBase64Url(JSON.stringify(header))}.${toBase64Url(JSON.stringify(claims))}`;
+  const signer = createSign("RSA-SHA256");
+
+  signer.update(unsignedToken);
+  signer.end();
+
+  return `${unsignedToken}.${toBase64Url(signer.sign(serviceAccount.privateKey))}`;
+};
+
+const getGoogleAccessToken = async (
+  serviceAccount: GoogleServiceAccount
+): Promise<string> => {
+  const tokenResponse = await fetch(serviceAccount.tokenUri, {
+    body: new URLSearchParams({
+      assertion: buildSignedJwt(serviceAccount),
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    }),
+    cache: "no-store",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    method: "POST",
+  });
+
+  if (!tokenResponse.ok) {
+    throw new Error(
+      `Google token exchange failed: ${tokenResponse.status} ${tokenResponse.statusText}`
+    );
+  }
+
+  const body = (await tokenResponse.json()) as { access_token?: string };
+
+  if (!body.access_token) {
+    throw new Error("Google token exchange did not return an access token.");
+  }
+
+  return body.access_token;
+};
+
+export const readGoogleSheetValues = async (
+  config: GoogleSheetsSourceConfig
+): Promise<GoogleSheetsReadResult> => {
+  const fixtureValues = getTestFixtureValues();
+  const startedAt = Date.now();
+
+  if (fixtureValues) {
+    return {
+      durationMs: Date.now() - startedAt,
+      values: fixtureValues,
+      valuesSource: "test_fixture",
+    };
+  }
+
+  const serviceAccount = getGoogleServiceAccount();
+  const accessToken = await getGoogleAccessToken(serviceAccount);
+  const valueRange = buildGoogleSheetsValueRange(config);
+  const sheetsResponse = await fetch(
+    `https://sheets.googleapis.com/v4/spreadsheets/${encodeURIComponent(config.spreadsheetId)}/values/${encodeURIComponent(valueRange)}`,
+    {
+      cache: "no-store",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+      method: "GET",
+    }
+  );
+
+  if (!sheetsResponse.ok) {
+    throw new Error(
+      `Google Sheets read failed: ${sheetsResponse.status} ${sheetsResponse.statusText}`
+    );
+  }
+
+  const body = (await sheetsResponse.json()) as {
+    values?: unknown;
+  };
+  const parsedValues = z.array(z.array(z.string())).safeParse(body.values);
+
+  return {
+    durationMs: Date.now() - startedAt,
+    values: parsedValues.success ? parsedValues.data : [],
+    valuesSource: "google_api",
+  };
+};

--- a/src/features/admin/operations/page.tsx
+++ b/src/features/admin/operations/page.tsx
@@ -1,3 +1,7 @@
+import Link from "next/link";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -5,49 +9,696 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import type { AdminOversightStatus } from "@/features/admin/shared";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  formatAdminDateTime,
+  type OperationRunStatus,
+  operationRunStatusLabel,
+} from "@/features/admin/shared";
 import { AdminModuleShell } from "@/features/admin/ui/admin-module-shell";
+import { routes } from "@/lib/routes";
 
-const routeByKey = {
-  apis: "/app/admin/apis",
-  "ingestion-runs": "/app/admin/ingestion-runs",
-  "pipeline-runs": "/app/admin/pipeline-runs",
-} as const satisfies Record<AdminOversightStatus["key"], string>;
+import {
+  toggleRegisteredSourceEnabledAction,
+  triggerRegisteredSourceReadAction,
+} from "./actions";
+import type {
+  AdminIngestionRunDetail,
+  AdminIngestionRunsPageData,
+  AdminPipelineRunDetail,
+  AdminPipelineRunsPageData,
+} from "./server";
+import { isDeferredPipelineRun } from "./server";
+import { RegisteredSourceForm } from "./source-form";
 
-export const AdminOversightPageView = ({
-  description,
-  integrationNotes,
-  key,
-  title,
-}: AdminOversightStatus) => {
+const operationStatusBadgeClassName: Record<OperationRunStatus, string> = {
+  failed: "border-red-200 bg-red-50 text-red-700",
+  queued: "border-zinc-200 bg-zinc-100 text-zinc-700",
+  running: "border-blue-200 bg-blue-50 text-blue-700",
+  succeeded: "border-emerald-200 bg-emerald-50 text-emerald-700",
+};
+
+const getIngestionRunsHref = (sourceId?: string, runId?: string): string => {
+  const params = new URLSearchParams();
+
+  if (sourceId) {
+    params.set("sourceId", sourceId);
+  }
+
+  if (runId) {
+    params.set("runId", runId);
+  }
+
+  const query = params.toString();
+
+  return query
+    ? `${routes.adminIngestionRuns}?${query}`
+    : routes.adminIngestionRuns;
+};
+
+const getPipelineRunsHref = (runId?: string): string => {
+  const params = new URLSearchParams();
+
+  if (runId) {
+    params.set("runId", runId);
+  }
+
+  const query = params.toString();
+
+  return query
+    ? `${routes.adminPipelineRuns}?${query}`
+    : routes.adminPipelineRuns;
+};
+
+const getRegisteredSourceFormDefaults = (
+  source?: {
+    description: string | null;
+    id: string;
+    isEnabled: boolean;
+    name: string;
+    range: string;
+    sheetName: string;
+    spreadsheetId: string;
+  } | null
+) => {
+  if (!source) {
+    return {
+      description: "",
+      isEnabled: true,
+      name: "",
+      range: "",
+      sheetName: "",
+      sourceId: undefined,
+      spreadsheetId: "",
+    };
+  }
+
+  return {
+    description: source.description ?? "",
+    isEnabled: source.isEnabled,
+    name: source.name,
+    range: source.range,
+    sheetName: source.sheetName,
+    sourceId: source.id,
+    spreadsheetId: source.spreadsheetId,
+  };
+};
+
+const RunStatusBadge = ({ status }: { status: OperationRunStatus }) => {
   return (
-    <AdminModuleShell
-      description={description}
-      route={routeByKey[key]}
-      title={title}
-    >
+    <Badge className={operationStatusBadgeClassName[status]}>
+      {operationRunStatusLabel[status]}
+    </Badge>
+  );
+};
+
+const buildStablePreviewKeys = (values: string[]) => {
+  const occurrences = new Map<string, number>();
+
+  return values.map((value) => {
+    const nextOccurrence = (occurrences.get(value) ?? 0) + 1;
+
+    occurrences.set(value, nextOccurrence);
+
+    return {
+      key: `${value || "blank"}-${nextOccurrence}`,
+      value,
+    };
+  });
+};
+
+const IngestionRunDetailCard = ({
+  detail,
+}: {
+  detail: AdminIngestionRunDetail | null;
+}) => {
+  if (!detail) {
+    return (
       <Card>
         <CardHeader>
-          <CardTitle>Integration boundary ready</CardTitle>
+          <CardTitle>Run details</CardTitle>
           <CardDescription>
-            The admin route exists, is protected, and has a typed adapter
-            boundary. Live oversight stops here until a real backing source is
-            confirmed.
+            Select a run to inspect bounded source-read metadata.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  const previewHeaders =
+    detail.storedHeaders.length > 0
+      ? detail.storedHeaders
+      : Array.from(
+          {
+            length: detail.sampleRows.reduce((maxColumns, row) => {
+              return Math.max(maxColumns, row.length);
+            }, 0),
+          },
+          (_, index) => `Column ${index + 1}`
+        );
+  const previewColumns = buildStablePreviewKeys(previewHeaders);
+  const previewRows = buildStablePreviewKeys(
+    detail.sampleRows.map((row) => JSON.stringify(row))
+  ).map((entry, index) => ({
+    key: `${detail.run.id}-${entry.key}`,
+    values: detail.sampleRows[index] ?? [],
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <CardTitle>Run details</CardTitle>
+            <CardDescription>
+              Inspect the exact bounded metadata captured for this source-read
+              operation.
+            </CardDescription>
+          </div>
+          <RunStatusBadge status={detail.run.status} />
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <div className="grid gap-6 lg:grid-cols-2">
+          <div className="space-y-2 text-sm">
+            <p className="font-medium">Source snapshot</p>
+            {detail.sourceConfigLines.map((line) => (
+              <p className="text-muted-foreground" key={line}>
+                {line}
+              </p>
+            ))}
+          </div>
+          <div className="space-y-2 text-sm">
+            <p className="font-medium">Run summary</p>
+            {detail.metadataLines.map((line) => (
+              <p className="text-muted-foreground" key={line}>
+                {line}
+              </p>
+            ))}
+          </div>
+        </div>
+        {detail.run.errorMessage ? (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-destructive text-sm">
+            {detail.run.errorMessage}
+          </div>
+        ) : null}
+        {detail.truncatedNotes.length > 0 ? (
+          <div className="space-y-2 rounded-lg border bg-muted/20 px-4 py-3 text-sm">
+            <p className="font-medium">Bounded storage notes</p>
+            {detail.truncatedNotes.map((line) => (
+              <p className="text-muted-foreground" key={line}>
+                {line}
+              </p>
+            ))}
+          </div>
+        ) : null}
+        <div className="space-y-3">
+          <div>
+            <p className="font-medium text-sm">Stored sample rows</p>
+            <p className="text-muted-foreground text-sm">
+              Stored strictly for bounded operator inspection, not as staging or
+              publishable data.
+            </p>
+          </div>
+          {detail.sampleRows.length === 0 ? (
+            <div className="rounded-lg border bg-muted/20 px-4 py-3 text-muted-foreground text-sm">
+              No sample rows were stored for this run.
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded-lg border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    {previewColumns.map((column) => (
+                      <TableHead key={column.key}>{column.value}</TableHead>
+                    ))}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {previewRows.map((row) => (
+                    <TableRow key={row.key}>
+                      {previewColumns.map((column, columnIndex) => (
+                        <TableCell key={`${row.key}-${column.key}`}>
+                          {row.values[columnIndex] ?? ""}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export const AdminIngestionRunsPageView = ({
+  runs,
+  selectedRun,
+  selectedSource,
+  selectedSourceId,
+  sources,
+}: AdminIngestionRunsPageData) => {
+  return (
+    <AdminModuleShell
+      description="Register bounded sources, trigger source reads, and inspect durable ingestion history without turning this phase into a background job system."
+      route={routes.adminIngestionRuns}
+      title="Ingestion Runs"
+    >
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,24rem)_minmax(0,1fr)]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Register source</CardTitle>
+            <CardDescription>
+              Phase B stores non-secret source metadata only. Credentials stay
+              in environment-level secret storage.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <RegisteredSourceForm
+              defaultValues={getRegisteredSourceFormDefaults()}
+              mode="create"
+            />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>
+              {selectedSource ? "Edit selected source" : "Source details"}
+            </CardTitle>
+            <CardDescription>
+              {selectedSource
+                ? "Light edits only: name, description, bounded range, and enabled state."
+                : "Select a source from the registry to edit its bounded non-secret configuration."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {selectedSource ? (
+              <>
+                <div className="grid gap-3 md:grid-cols-3">
+                  <div className="rounded-lg border bg-muted/20 px-4 py-3 text-sm">
+                    <p className="font-medium">Slug</p>
+                    <p className="text-muted-foreground">
+                      {selectedSource.slug}
+                    </p>
+                  </div>
+                  <div className="rounded-lg border bg-muted/20 px-4 py-3 text-sm">
+                    <p className="font-medium">Ingestion runs</p>
+                    <p className="text-muted-foreground">
+                      {selectedSource.ingestionRunCount.toLocaleString()}
+                    </p>
+                  </div>
+                  <div className="rounded-lg border bg-muted/20 px-4 py-3 text-sm">
+                    <p className="font-medium">Pipeline scaffold runs</p>
+                    <p className="text-muted-foreground">
+                      {selectedSource.pipelineRunCount.toLocaleString()}
+                    </p>
+                  </div>
+                </div>
+                <RegisteredSourceForm
+                  defaultValues={getRegisteredSourceFormDefaults({
+                    description: selectedSource.description,
+                    id: selectedSource.id,
+                    isEnabled: selectedSource.isEnabled,
+                    name: selectedSource.name,
+                    range: selectedSource.range,
+                    sheetName: selectedSource.sheetName,
+                    spreadsheetId: selectedSource.spreadsheetId,
+                  })}
+                  mode="edit"
+                />
+              </>
+            ) : (
+              <div className="rounded-lg border bg-muted/20 px-4 py-3 text-muted-foreground text-sm">
+                No sources are registered yet.
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Registered sources</CardTitle>
+          <CardDescription>
+            Trigger the first bounded Google Sheets read here. Successful runs
+            create downstream scaffold rows only.
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <ul className="space-y-2 text-sm">
-            {integrationNotes.map((note) => (
-              <li
-                className="rounded-lg border bg-muted/20 px-4 py-3"
-                key={note}
-              >
-                {note}
-              </li>
-            ))}
-          </ul>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Source</TableHead>
+                <TableHead>Config</TableHead>
+                <TableHead>State</TableHead>
+                <TableHead>Last run</TableHead>
+                <TableHead>History</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sources.length === 0 ? (
+                <TableRow>
+                  <TableCell className="text-muted-foreground" colSpan={6}>
+                    No sources are registered yet.
+                  </TableCell>
+                </TableRow>
+              ) : null}
+              {sources.map((source) => (
+                <TableRow key={source.id}>
+                  <TableCell>
+                    <div className="space-y-1">
+                      <div className="flex items-center gap-2">
+                        <p className="font-medium">{source.name}</p>
+                        {source.id === selectedSourceId ? (
+                          <Badge variant="secondary">Inspecting</Badge>
+                        ) : null}
+                      </div>
+                      <p className="text-muted-foreground text-sm">
+                        {source.slug}
+                      </p>
+                      <p className="text-muted-foreground text-xs">
+                        {source.connectorKind}
+                      </p>
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-sm">
+                    <p>{source.sheetName || "No sheet name"}</p>
+                    <p className="text-muted-foreground text-xs">
+                      {source.range || "No range"} /{" "}
+                      {source.spreadsheetId || "No spreadsheet id"}
+                    </p>
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex flex-col gap-2">
+                      <Badge
+                        className={
+                          source.isEnabled
+                            ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+                            : "border-zinc-200 bg-zinc-100 text-zinc-700"
+                        }
+                      >
+                        {source.isEnabled ? "Enabled" : "Disabled"}
+                      </Badge>
+                      {source.lastRunStatus ? (
+                        <RunStatusBadge status={source.lastRunStatus} />
+                      ) : (
+                        <span className="text-muted-foreground text-xs">
+                          Never run
+                        </span>
+                      )}
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-sm">
+                    {source.lastRunAt
+                      ? formatAdminDateTime(source.lastRunAt)
+                      : "Never run"}
+                  </TableCell>
+                  <TableCell className="text-sm">
+                    <p>{source.ingestionRunCount.toLocaleString()} ingestion</p>
+                    <p className="text-muted-foreground text-xs">
+                      {source.pipelineRunCount.toLocaleString()} deferred
+                      pipeline
+                    </p>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-2">
+                      <Button asChild size="sm" variant="ghost">
+                        <Link href={getIngestionRunsHref(source.id)}>
+                          Inspect
+                        </Link>
+                      </Button>
+                      <form action={toggleRegisteredSourceEnabledAction}>
+                        <input
+                          name="sourceId"
+                          type="hidden"
+                          value={source.id}
+                        />
+                        <input
+                          name="nextEnabled"
+                          type="hidden"
+                          value={source.isEnabled ? "false" : "true"}
+                        />
+                        <Button size="sm" type="submit" variant="outline">
+                          {source.isEnabled ? "Disable" : "Enable"}
+                        </Button>
+                      </form>
+                      <form action={triggerRegisteredSourceReadAction}>
+                        <input
+                          name="sourceId"
+                          type="hidden"
+                          value={source.id}
+                        />
+                        <Button
+                          disabled={!source.isEnabled}
+                          size="sm"
+                          type="submit"
+                        >
+                          Run read
+                        </Button>
+                      </form>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
         </CardContent>
       </Card>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Run history</CardTitle>
+            <CardDescription>
+              {selectedSource
+                ? `Ingestion history for ${selectedSource.name}.`
+                : "Select a source to focus its run history."}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Created</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Requested by</TableHead>
+                  <TableHead>Started</TableHead>
+                  <TableHead>Completed</TableHead>
+                  <TableHead className="text-right">Inspect</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {runs.length === 0 ? (
+                  <TableRow>
+                    <TableCell className="text-muted-foreground" colSpan={6}>
+                      No ingestion runs exist for the current source selection.
+                    </TableCell>
+                  </TableRow>
+                ) : null}
+                {runs.map((run) => (
+                  <TableRow key={run.id}>
+                    <TableCell>{formatAdminDateTime(run.createdAt)}</TableCell>
+                    <TableCell>
+                      <RunStatusBadge status={run.status} />
+                    </TableCell>
+                    <TableCell>
+                      <div className="space-y-1">
+                        <p>
+                          {run.requestedByDisplayName ?? "Unknown operator"}
+                        </p>
+                        <p className="text-muted-foreground text-xs">
+                          {run.requestedByEmail ?? "Email unavailable"}
+                        </p>
+                      </div>
+                    </TableCell>
+                    <TableCell>{formatAdminDateTime(run.startedAt)}</TableCell>
+                    <TableCell>
+                      {formatAdminDateTime(run.completedAt)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button asChild size="sm" variant="ghost">
+                        <Link href={getIngestionRunsHref(run.sourceId, run.id)}>
+                          Inspect
+                        </Link>
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+        <IngestionRunDetailCard detail={selectedRun} />
+      </div>
+    </AdminModuleShell>
+  );
+};
+
+const PipelineRunDetailCard = ({
+  detail,
+}: {
+  detail: AdminPipelineRunDetail | null;
+}) => {
+  if (!detail) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Run details</CardTitle>
+          <CardDescription>
+            Select a deferred pipeline scaffold run to inspect its metadata.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <CardTitle>Run details</CardTitle>
+            <CardDescription>
+              This section remains explicitly scaffold-only in Phase B.
+            </CardDescription>
+          </div>
+          <RunStatusBadge status={detail.run.status} />
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm">
+        {detail.metadataLines.map((line) => (
+          <p className="text-muted-foreground" key={line}>
+            {line}
+          </p>
+        ))}
+        {detail.run.errorMessage ? (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-destructive text-sm">
+            {detail.run.errorMessage}
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+};
+
+export const AdminPipelineRunsPageView = ({
+  runs,
+  selectedRun,
+}: AdminPipelineRunsPageData) => {
+  return (
+    <AdminModuleShell
+      description="Inspect the downstream scaffold rows created by successful source reads. This page does not represent executed pipeline jobs yet."
+      route={routes.adminPipelineRuns}
+      title="Pipeline Runs"
+    >
+      <Card>
+        <CardHeader>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <CardTitle>Deferred scaffold only</CardTitle>
+              <CardDescription>
+                These rows exist so future connectors and background execution
+                can reuse a durable operational model. Phase B does not execute
+                downstream pipeline steps.
+              </CardDescription>
+            </div>
+            <Badge className="border-orange-200 bg-orange-50 text-orange-700">
+              Deferred scaffold only
+            </Badge>
+          </div>
+        </CardHeader>
+      </Card>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Run history</CardTitle>
+            <CardDescription>
+              Every row here should remain visibly non-executing until a future
+              pipeline phase adds real orchestration.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Created</TableHead>
+                  <TableHead>Source</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Mode</TableHead>
+                  <TableHead>Requested by</TableHead>
+                  <TableHead className="text-right">Inspect</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {runs.length === 0 ? (
+                  <TableRow>
+                    <TableCell className="text-muted-foreground" colSpan={6}>
+                      No pipeline scaffold runs have been recorded yet.
+                    </TableCell>
+                  </TableRow>
+                ) : null}
+                {runs.map((run) => (
+                  <TableRow key={run.id}>
+                    <TableCell>{formatAdminDateTime(run.createdAt)}</TableCell>
+                    <TableCell>
+                      <div className="space-y-1">
+                        <p>{run.sourceName}</p>
+                        <p className="text-muted-foreground text-xs">
+                          {run.sourceSlug}
+                        </p>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-col gap-2">
+                        <RunStatusBadge status={run.status} />
+                        {isDeferredPipelineRun(run) ? (
+                          <Badge
+                            className="border-orange-200 bg-orange-50 text-orange-700"
+                            variant="outline"
+                          >
+                            Deferred
+                          </Badge>
+                        ) : null}
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-sm">
+                      {run.executionMode}
+                    </TableCell>
+                    <TableCell>
+                      <div className="space-y-1">
+                        <p>
+                          {run.requestedByDisplayName ?? "Unknown operator"}
+                        </p>
+                        <p className="text-muted-foreground text-xs">
+                          {run.requestedByEmail ?? "Email unavailable"}
+                        </p>
+                      </div>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button asChild size="sm" variant="ghost">
+                        <Link href={getPipelineRunsHref(run.id)}>Inspect</Link>
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+        <PipelineRunDetailCard detail={selectedRun} />
+      </div>
     </AdminModuleShell>
   );
 };

--- a/src/features/admin/operations/server.ts
+++ b/src/features/admin/operations/server.ts
@@ -1,51 +1,479 @@
 import "server-only";
 
-import type { AdminOversightStatus } from "@/features/admin/shared";
+import {
+  listAdminAuthUsers,
+  listAdminIngestionRuns,
+  listAdminPipelineRuns,
+  listAdminProfiles,
+  listAdminRegisteredSources,
+} from "@/features/admin/server";
+import type {
+  AdminIngestionRunRecord,
+  AdminPipelineRunRecord,
+  AdminRegisteredSourceRecord,
+} from "@/features/admin/shared";
 import { requireCurrentUserAdmin } from "@/lib/auth/server";
+import type { Tables } from "@/lib/supabase/database.types";
 
-const oversightStatuses = {
-  apis: {
-    description:
-      "API oversight is reserved for a future backing source such as confirmed external API registrations, credentials, or health views.",
-    integrationNotes: [
-      "Provide a confirmed API registry table, view, or external source.",
-      "Confirm which status fields and diagnostics belong in the oversight UI.",
-      "Wire the adapter in this module instead of adding permanent fake schema.",
-    ],
-    key: "apis",
-    title: "APIs",
-  },
-  "ingestion-runs": {
-    description:
-      "Ingestion-run oversight needs a real run-history source before this route can move beyond placeholder depth.",
-    integrationNotes: [
-      "Provide a confirmed ingestion run table, view, or external operational feed.",
-      "Confirm run status, timing, and failure fields.",
-      "Replace the placeholder adapter implementation when the source exists.",
-    ],
-    key: "ingestion-runs",
-    title: "Ingestion Runs",
-  },
-  "pipeline-runs": {
-    description:
-      "Pipeline-run oversight needs a real orchestration or run-history source before the page can render live diagnostics.",
-    integrationNotes: [
-      "Provide a confirmed pipeline run table, view, or external operational feed.",
-      "Confirm run lineage, failure, and retry metadata.",
-      "Replace the placeholder adapter implementation when the source exists.",
-    ],
-    key: "pipeline-runs",
-    title: "Pipeline Runs",
-  },
-} as const satisfies Record<AdminOversightStatus["key"], AdminOversightStatus>;
+import {
+  parseDeferredPipelineMetadata,
+  parseGoogleSheetsSourceConfig,
+  parseIngestionRunMetadata,
+  pipelineExecutionMode,
+  pipelineKey,
+} from "./source-config";
 
-export const loadAdminOversightPage = async (
-  key: AdminOversightStatus["key"]
-): Promise<AdminOversightStatus> => {
+const normalizeSearchParam = (value: string | string[] | undefined): string => {
+  if (Array.isArray(value)) {
+    return value[0]?.trim() ?? "";
+  }
+
+  return value?.trim() ?? "";
+};
+
+const getSelectedSourceId = (
+  searchParams: Record<string, string | string[] | undefined>,
+  sources: AdminRegisteredSourceRecord[]
+): string | null => {
+  const sourceId = normalizeSearchParam(searchParams.sourceId);
+
+  if (sourceId && sources.some((source) => source.id === sourceId)) {
+    return sourceId;
+  }
+
+  return sources[0]?.id ?? null;
+};
+
+const getSelectedRunId = <
+  TRun extends {
+    id: string;
+  },
+>(
+  searchParams: Record<string, string | string[] | undefined>,
+  runs: TRun[]
+): string | null => {
+  const runId = normalizeSearchParam(searchParams.runId);
+
+  if (runId && runs.some((run) => run.id === runId)) {
+    return runId;
+  }
+
+  return runs[0]?.id ?? null;
+};
+
+const getRequestedByDetails = ({
+  authUsersById,
+  profileById,
+  userId,
+}: {
+  authUsersById: Map<string, { email?: string }>;
+  profileById: Map<string, Tables<"profiles">>;
+  userId: string | null;
+}) => {
+  if (!userId) {
+    return {
+      requestedByDisplayName: null,
+      requestedByEmail: null,
+      requestedByUserId: null,
+    };
+  }
+
+  return {
+    requestedByDisplayName: profileById.get(userId)?.display_name ?? null,
+    requestedByEmail: authUsersById.get(userId)?.email ?? null,
+    requestedByUserId: userId,
+  };
+};
+
+const mapRegisteredSourceRecord = ({
+  ingestionRunsBySourceId,
+  pipelineRunsBySourceId,
+  source,
+}: {
+  ingestionRunsBySourceId: Map<string, Tables<"ingestion_runs">[]>;
+  pipelineRunsBySourceId: Map<string, Tables<"pipeline_runs">[]>;
+  source: Tables<"registered_sources">;
+}): AdminRegisteredSourceRecord => {
+  const config = parseGoogleSheetsSourceConfig(source.config);
+  const ingestionRuns = ingestionRunsBySourceId.get(source.id) ?? [];
+  const pipelineRuns = pipelineRunsBySourceId.get(source.id) ?? [];
+
+  return {
+    connectorKind: source.connector_kind,
+    createdAt: source.created_at,
+    description: source.description,
+    id: source.id,
+    ingestionRunCount: ingestionRuns.length,
+    isEnabled: source.is_enabled,
+    lastIngestionRunId: ingestionRuns[0]?.id ?? null,
+    lastRunAt: source.last_run_at,
+    lastRunStatus: source.last_run_status,
+    name: source.name,
+    pipelineRunCount: pipelineRuns.length,
+    range: config?.range ?? "",
+    sheetName: config?.sheetName ?? "",
+    slug: source.slug,
+    spreadsheetId: config?.spreadsheetId ?? "",
+    updatedAt: source.updated_at,
+  };
+};
+
+const mapIngestionRunRecord = ({
+  authUsersById,
+  profileById,
+  run,
+  sourceById,
+}: {
+  authUsersById: Map<string, { email?: string }>;
+  profileById: Map<string, Tables<"profiles">>;
+  run: Tables<"ingestion_runs">;
+  sourceById: Map<string, AdminRegisteredSourceRecord>;
+}): AdminIngestionRunRecord | null => {
+  const source = sourceById.get(run.source_id);
+
+  if (!source) {
+    return null;
+  }
+
+  return {
+    completedAt: run.completed_at,
+    createdAt: run.created_at,
+    errorMessage: run.error_message,
+    id: run.id,
+    ...getRequestedByDetails({
+      authUsersById,
+      profileById,
+      userId: run.requested_by,
+    }),
+    runKind: run.run_kind,
+    sourceId: source.id,
+    sourceName: source.name,
+    sourceSlug: source.slug,
+    startedAt: run.started_at,
+    status: run.status,
+  };
+};
+
+const mapPipelineRunRecord = ({
+  authUsersById,
+  profileById,
+  run,
+  sourceById,
+}: {
+  authUsersById: Map<string, { email?: string }>;
+  profileById: Map<string, Tables<"profiles">>;
+  run: Tables<"pipeline_runs">;
+  sourceById: Map<string, AdminRegisteredSourceRecord>;
+}): AdminPipelineRunRecord | null => {
+  const source = sourceById.get(run.source_id);
+
+  if (!source) {
+    return null;
+  }
+
+  return {
+    completedAt: run.completed_at,
+    createdAt: run.created_at,
+    errorMessage: run.error_message,
+    executionMode: run.execution_mode,
+    id: run.id,
+    ingestionRunId: run.ingestion_run_id,
+    pipelineKey: run.pipeline_key,
+    ...getRequestedByDetails({
+      authUsersById,
+      profileById,
+      userId: run.requested_by,
+    }),
+    sourceId: source.id,
+    sourceName: source.name,
+    sourceSlug: source.slug,
+    startedAt: run.started_at,
+    status: run.status,
+  };
+};
+
+export interface AdminIngestionRunDetail {
+  metadataLines: string[];
+  rawRun: Tables<"ingestion_runs">;
+  run: AdminIngestionRunRecord;
+  sampleRows: string[][];
+  sourceConfigLines: string[];
+  storedHeaders: string[];
+  truncatedNotes: string[];
+}
+
+export interface AdminIngestionRunsPageData {
+  runs: AdminIngestionRunRecord[];
+  selectedRun: AdminIngestionRunDetail | null;
+  selectedRunId: string | null;
+  selectedSource: AdminRegisteredSourceRecord | null;
+  selectedSourceId: string | null;
+  sources: AdminRegisteredSourceRecord[];
+}
+
+export interface AdminPipelineRunDetail {
+  metadataLines: string[];
+  rawRun: Tables<"pipeline_runs">;
+  run: AdminPipelineRunRecord;
+}
+
+export interface AdminPipelineRunsPageData {
+  runs: AdminPipelineRunRecord[];
+  selectedRun: AdminPipelineRunDetail | null;
+  selectedRunId: string | null;
+}
+
+const buildIngestionRunDetail = ({
+  run,
+  runRow,
+}: {
+  run: AdminIngestionRunRecord;
+  runRow: Tables<"ingestion_runs">;
+}): AdminIngestionRunDetail => {
+  const metadata = parseIngestionRunMetadata(runRow.metadata);
+  const sourceConfig = parseGoogleSheetsSourceConfig(
+    runRow.source_config_snapshot
+  );
+  const truncatedNotes: string[] = [];
+
+  if (metadata.truncated.headers) {
+    truncatedNotes.push("Stored headers were capped to the first 50 columns.");
+  }
+
+  if (metadata.truncated.sampleRows) {
+    truncatedNotes.push("Stored sample rows were capped to the first 10 rows.");
+  }
+
+  if (metadata.truncated.cellValues) {
+    truncatedNotes.push("Long cell values were truncated to 200 characters.");
+  }
+
+  if (metadata.truncated.metadata) {
+    truncatedNotes.push(
+      "Sample metadata was further trimmed to stay under 32 KB."
+    );
+  }
+
+  return {
+    metadataLines: [
+      `Read mode: ${metadata.valuesSource === "test_fixture" ? "Playwright fixture" : "Live Google Sheets API"}`,
+      `Raw rows returned: ${metadata.rawRowCount.toLocaleString()}`,
+      `Data rows after header: ${metadata.dataRowCount.toLocaleString()}`,
+      `Detected columns: ${metadata.columnCount?.toLocaleString() ?? "Unavailable"}`,
+      `Stored metadata size: ${metadata.metadataBytes?.toLocaleString() ?? "Unavailable"} bytes`,
+      `Connector duration: ${metadata.connectorDurationMs?.toLocaleString() ?? "Unavailable"} ms`,
+    ],
+    rawRun: runRow,
+    run,
+    sampleRows: metadata.sampleRows,
+    sourceConfigLines: [
+      `Connector: ${run.sourceName} (${run.sourceSlug})`,
+      `Spreadsheet ID: ${sourceConfig?.spreadsheetId ?? "Unavailable"}`,
+      `Sheet: ${sourceConfig?.sheetName ?? "Unavailable"}`,
+      `Range: ${sourceConfig?.range ?? "Unavailable"}`,
+    ],
+    storedHeaders: metadata.headers,
+    truncatedNotes,
+  };
+};
+
+const buildPipelineRunDetail = ({
+  run,
+  runRow,
+}: {
+  run: AdminPipelineRunRecord;
+  runRow: Tables<"pipeline_runs">;
+}): AdminPipelineRunDetail => {
+  const metadata = parseDeferredPipelineMetadata(runRow.metadata);
+
+  return {
+    metadataLines: [
+      `Pipeline key: ${run.pipelineKey}`,
+      `Execution mode: ${run.executionMode}`,
+      `Deferred scaffold only: ${run.executionMode === pipelineExecutionMode.deferredScaffold ? "Yes" : "No"}`,
+      `Created from ingestion run: ${run.ingestionRunId ?? "Unavailable"}`,
+      `Source rows observed: ${metadata?.sourceReadSummary.dataRowCount.toLocaleString() ?? "Unavailable"}`,
+      `Source columns observed: ${metadata?.sourceReadSummary.columnCount?.toLocaleString() ?? "Unavailable"}`,
+      metadata?.reason ??
+        "Phase B stores the downstream placeholder only. No pipeline execution is implemented yet.",
+    ],
+    rawRun: runRow,
+    run,
+  };
+};
+
+export const loadAdminIngestionRunsPage = async (
+  searchParams: Record<string, string | string[] | undefined>
+): Promise<AdminIngestionRunsPageData> => {
   await requireCurrentUserAdmin();
 
-  // TODO(phase-6): Replace this placeholder adapter with a real data source
-  // once the repository gains confirmed backing tables, views, or external
-  // operational integrations for these admin oversight surfaces.
-  return oversightStatuses[key];
+  const [profiles, authUsers, rawSources, rawIngestionRuns, rawPipelineRuns] =
+    await Promise.all([
+      listAdminProfiles(),
+      listAdminAuthUsers(),
+      listAdminRegisteredSources(),
+      listAdminIngestionRuns(),
+      listAdminPipelineRuns(),
+    ]);
+  const profileById = new Map(
+    profiles.map((profile) => [profile.user_id, profile] as const)
+  );
+  const authUsersById = new Map(
+    Array.from(authUsers.usersById.entries()).map(([userId, user]) => {
+      return [userId, { email: user.email }] as const;
+    })
+  );
+  const ingestionRunsBySourceId = new Map<string, Tables<"ingestion_runs">[]>();
+  const pipelineRunsBySourceId = new Map<string, Tables<"pipeline_runs">[]>();
+
+  for (const run of rawIngestionRuns) {
+    const currentRuns = ingestionRunsBySourceId.get(run.source_id) ?? [];
+
+    currentRuns.push(run);
+    ingestionRunsBySourceId.set(run.source_id, currentRuns);
+  }
+
+  for (const run of rawPipelineRuns) {
+    const currentRuns = pipelineRunsBySourceId.get(run.source_id) ?? [];
+
+    currentRuns.push(run);
+    pipelineRunsBySourceId.set(run.source_id, currentRuns);
+  }
+
+  const sources = rawSources.map((source) => {
+    return mapRegisteredSourceRecord({
+      ingestionRunsBySourceId,
+      pipelineRunsBySourceId,
+      source,
+    });
+  });
+  const sourceById = new Map(
+    sources.map((source) => [source.id, source] as const)
+  );
+  const selectedSourceId = getSelectedSourceId(searchParams, sources);
+  const selectedSource = selectedSourceId
+    ? (sourceById.get(selectedSourceId) ?? null)
+    : null;
+  const runs = rawIngestionRuns
+    .map((run) => {
+      return mapIngestionRunRecord({
+        authUsersById,
+        profileById,
+        run,
+        sourceById,
+      });
+    })
+    .filter((run): run is AdminIngestionRunRecord => Boolean(run))
+    .filter((run) => {
+      if (!selectedSourceId) {
+        return true;
+      }
+
+      return run.sourceId === selectedSourceId;
+    });
+  const rawRunById = new Map(
+    rawIngestionRuns.map((run) => [run.id, run] as const)
+  );
+  const selectedRunId = getSelectedRunId(searchParams, runs);
+  const selectedRunRecord = selectedRunId
+    ? (runs.find((run) => run.id === selectedRunId) ?? null)
+    : null;
+  const selectedRawRun = selectedRunRecord
+    ? (rawRunById.get(selectedRunRecord.id) ?? null)
+    : null;
+  const selectedRun =
+    selectedRunRecord && selectedRawRun
+      ? buildIngestionRunDetail({
+          run: selectedRunRecord,
+          runRow: selectedRawRun,
+        })
+      : null;
+
+  return {
+    runs,
+    selectedRun,
+    selectedRunId,
+    selectedSource,
+    selectedSourceId,
+    sources,
+  };
+};
+
+export const loadAdminPipelineRunsPage = async (
+  searchParams: Record<string, string | string[] | undefined>
+): Promise<AdminPipelineRunsPageData> => {
+  await requireCurrentUserAdmin();
+
+  const [profiles, authUsers, rawSources, rawPipelineRuns] = await Promise.all([
+    listAdminProfiles(),
+    listAdminAuthUsers(),
+    listAdminRegisteredSources(),
+    listAdminPipelineRuns(),
+  ]);
+  const profileById = new Map(
+    profiles.map((profile) => [profile.user_id, profile] as const)
+  );
+  const authUsersById = new Map(
+    Array.from(authUsers.usersById.entries()).map(([userId, user]) => {
+      return [userId, { email: user.email }] as const;
+    })
+  );
+  const sources = rawSources.map((source) => {
+    return mapRegisteredSourceRecord({
+      ingestionRunsBySourceId: new Map(),
+      pipelineRunsBySourceId: new Map(),
+      source,
+    });
+  });
+  const sourceById = new Map(
+    sources.map((source) => [source.id, source] as const)
+  );
+  const requestedSourceId = normalizeSearchParam(searchParams.sourceId);
+  const runs = rawPipelineRuns
+    .map((run) => {
+      return mapPipelineRunRecord({
+        authUsersById,
+        profileById,
+        run,
+        sourceById,
+      });
+    })
+    .filter((run): run is AdminPipelineRunRecord => Boolean(run))
+    .filter((run) => {
+      if (!requestedSourceId) {
+        return true;
+      }
+
+      return run.sourceId === requestedSourceId;
+    });
+  const rawRunById = new Map(
+    rawPipelineRuns.map((run) => [run.id, run] as const)
+  );
+  const selectedRunId = getSelectedRunId(searchParams, runs);
+  const selectedRunRecord = selectedRunId
+    ? (runs.find((run) => run.id === selectedRunId) ?? null)
+    : null;
+  const selectedRawRun = selectedRunRecord
+    ? (rawRunById.get(selectedRunRecord.id) ?? null)
+    : null;
+  const selectedRun =
+    selectedRunRecord && selectedRawRun
+      ? buildPipelineRunDetail({
+          run: selectedRunRecord,
+          runRow: selectedRawRun,
+        })
+      : null;
+
+  return {
+    runs,
+    selectedRun,
+    selectedRunId,
+  };
+};
+
+export const isDeferredPipelineRun = (run: AdminPipelineRunRecord): boolean => {
+  return (
+    run.executionMode === pipelineExecutionMode.deferredScaffold &&
+    run.pipelineKey === pipelineKey.sourceIngestionScaffold
+  );
 };

--- a/src/features/admin/operations/source-config.ts
+++ b/src/features/admin/operations/source-config.ts
@@ -1,0 +1,288 @@
+import { z } from "zod";
+
+import { normalizeJsonRecord } from "@/features/datasets/types";
+import type { Json } from "@/lib/supabase/database.types";
+
+export const registeredSourceConnectorKind = {
+  googleSheets: "google_sheets",
+} as const;
+
+export const ingestionRunKind = {
+  sourceRead: "source_read",
+} as const;
+
+export const pipelineExecutionMode = {
+  deferredScaffold: "deferred_scaffold",
+} as const;
+
+export const pipelineKey = {
+  sourceIngestionScaffold: "source_ingestion_scaffold",
+} as const;
+
+export const publishRunActionType = {
+  activateDatasetVersion: "activate_dataset_version",
+} as const;
+
+export const sourceReadBounds = {
+  maxConfiguredRowSpan: 2000,
+  maxHeaderCount: 50,
+  maxMetadataBytes: 32 * 1024,
+  maxSampleRows: 10,
+  maxStoredCellLength: 200,
+} as const;
+
+const sheetNameSchema = z.string().trim().min(1).max(100);
+
+const spreadsheetIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(200)
+  .regex(
+    /^[A-Za-z0-9-_]+$/,
+    "Spreadsheet id must use Google Sheets id characters only."
+  );
+
+const boundedA1RangeSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .regex(
+    /^[A-Z]{1,3}\d+:[A-Z]{1,3}\d+$/i,
+    "Range must be an explicit bounded A1 range like A1:Z200."
+  )
+  .transform((value) => value.toUpperCase())
+  .superRefine((value: string, context: z.RefinementCtx) => {
+    const parsedRange = parseBoundedA1Range(value);
+
+    if (!parsedRange) {
+      context.addIssue({
+        code: "custom",
+        message: "Range must be an explicit bounded A1 range like A1:Z200.",
+      });
+
+      return;
+    }
+
+    if (parsedRange.endRow < parsedRange.startRow) {
+      context.addIssue({
+        code: "custom",
+        message: "Range end row must be after the start row.",
+      });
+    }
+
+    if (parsedRange.endColumn < parsedRange.startColumn) {
+      context.addIssue({
+        code: "custom",
+        message: "Range end column must be after the start column.",
+      });
+    }
+
+    if (parsedRange.rowSpan > sourceReadBounds.maxConfiguredRowSpan) {
+      context.addIssue({
+        code: "custom",
+        message: `Range may span at most ${sourceReadBounds.maxConfiguredRowSpan} rows.`,
+      });
+    }
+  });
+
+export const googleSheetsSourceConfigSchema = z.object({
+  range: boundedA1RangeSchema,
+  sheetName: sheetNameSchema,
+  spreadsheetId: spreadsheetIdSchema,
+});
+
+export const registeredSourceFormSchema = z.object({
+  connectorKind: z.literal(registeredSourceConnectorKind.googleSheets),
+  description: z
+    .string()
+    .trim()
+    .max(500)
+    .transform((value) => (value ? value : null)),
+  isEnabled: z.coerce.boolean(),
+  name: z.string().trim().min(1).max(120),
+  range: boundedA1RangeSchema,
+  sheetName: sheetNameSchema,
+  sourceId: z
+    .string()
+    .trim()
+    .uuid()
+    .optional()
+    .or(z.literal("").transform(() => undefined)),
+  spreadsheetId: spreadsheetIdSchema,
+});
+
+export const ingestionRunMetadataSchema = z.object({
+  columnCount: z.number().int().nonnegative().nullable().default(null),
+  connectorDurationMs: z.number().int().nonnegative().nullable().default(null),
+  dataRowCount: z.number().int().nonnegative().default(0),
+  headers: z.array(z.string()).default([]),
+  metadataBytes: z.number().int().nonnegative().nullable().default(null),
+  rawRowCount: z.number().int().nonnegative().default(0),
+  sampleRows: z.array(z.array(z.string())).default([]),
+  truncated: z.object({
+    cellValues: z.boolean().default(false),
+    headers: z.boolean().default(false),
+    metadata: z.boolean().default(false),
+    sampleRows: z.boolean().default(false),
+  }),
+  valuesSource: z.string().trim().min(1).default("google_api"),
+});
+
+export const deferredPipelineMetadataSchema = z.object({
+  deferred: z.boolean().default(true),
+  executionMode: z
+    .literal(pipelineExecutionMode.deferredScaffold)
+    .default(pipelineExecutionMode.deferredScaffold),
+  ingestionRunId: z.string().uuid().nullable().default(null),
+  reason: z.string().trim().min(1),
+  sourceReadSummary: z
+    .object({
+      columnCount: z.number().int().nonnegative().nullable().default(null),
+      dataRowCount: z.number().int().nonnegative().default(0),
+      valuesSource: z.string().trim().min(1).default("google_api"),
+    })
+    .default({
+      columnCount: null,
+      dataRowCount: 0,
+      valuesSource: "google_api",
+    }),
+});
+
+export const publishRunMetadataSchema = z.object({
+  existingDomainHistoryTable: z.literal("dataset_version_events"),
+  operationWrapper: z.literal(true),
+  rpcResult: z.record(z.string(), z.unknown()).default({}),
+});
+
+export type GoogleSheetsSourceConfig = z.infer<
+  typeof googleSheetsSourceConfigSchema
+>;
+
+export type RegisteredSourceFormValues = z.infer<
+  typeof registeredSourceFormSchema
+>;
+
+export type IngestionRunMetadata = z.infer<typeof ingestionRunMetadataSchema>;
+export type DeferredPipelineMetadata = z.infer<
+  typeof deferredPipelineMetadataSchema
+>;
+export type PublishRunMetadata = z.infer<typeof publishRunMetadataSchema>;
+
+const boundedCellReferencePattern = /^([A-Z]{1,3})(\d+)$/;
+
+interface ParsedCellReference {
+  column: number;
+  row: number;
+}
+
+export interface ParsedBoundedA1Range {
+  endColumn: number;
+  endRow: number;
+  rowSpan: number;
+  startColumn: number;
+  startRow: number;
+}
+
+const parseCellReference = (value: string): ParsedCellReference | null => {
+  const match = boundedCellReferencePattern.exec(value);
+
+  if (!match) {
+    return null;
+  }
+
+  const [, columnLetters, rowDigits] = match;
+  let column = 0;
+
+  for (const letter of columnLetters) {
+    column = column * 26 + (letter.charCodeAt(0) - 64);
+  }
+
+  return {
+    column,
+    row: Number.parseInt(rowDigits, 10),
+  };
+};
+
+export const parseBoundedA1Range = (
+  value: string
+): ParsedBoundedA1Range | null => {
+  const [startReference, endReference] = value.split(":");
+
+  if (!(startReference && endReference)) {
+    return null;
+  }
+
+  const start = parseCellReference(startReference);
+  const end = parseCellReference(endReference);
+
+  if (!(start && end)) {
+    return null;
+  }
+
+  return {
+    endColumn: end.column,
+    endRow: end.row,
+    rowSpan: end.row - start.row + 1,
+    startColumn: start.column,
+    startRow: start.row,
+  };
+};
+
+export const parseGoogleSheetsSourceConfig = (
+  value: Json | null | undefined
+): GoogleSheetsSourceConfig | null => {
+  const parsedValue = googleSheetsSourceConfigSchema.safeParse(value);
+
+  if (parsedValue.success) {
+    return parsedValue.data;
+  }
+
+  return null;
+};
+
+export const parseIngestionRunMetadata = (
+  value: Json | null | undefined
+): IngestionRunMetadata => {
+  const parsedValue = ingestionRunMetadataSchema.safeParse(value);
+
+  if (parsedValue.success) {
+    return parsedValue.data;
+  }
+
+  return ingestionRunMetadataSchema.parse({});
+};
+
+export const parseDeferredPipelineMetadata = (
+  value: Json | null | undefined
+): DeferredPipelineMetadata | null => {
+  const parsedValue = deferredPipelineMetadataSchema.safeParse(value);
+
+  if (parsedValue.success) {
+    return parsedValue.data;
+  }
+
+  return null;
+};
+
+export const parsePublishRunMetadata = (
+  value: Json | null | undefined
+): PublishRunMetadata => {
+  const parsedValue = publishRunMetadataSchema.safeParse(value);
+
+  if (parsedValue.success) {
+    return parsedValue.data;
+  }
+
+  return publishRunMetadataSchema.parse({
+    rpcResult: normalizeJsonRecord(value),
+  });
+};
+
+export const buildGoogleSheetsValueRange = (
+  config: GoogleSheetsSourceConfig
+): string => {
+  const escapedSheetName = config.sheetName.replace(/'/g, "''");
+
+  return `'${escapedSheetName}'!${config.range}`;
+};

--- a/src/features/admin/operations/source-form.tsx
+++ b/src/features/admin/operations/source-form.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useActionState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { createInitialAdminActionState } from "@/features/admin/shared";
+
+import { saveRegisteredSourceAction } from "./actions";
+import { registeredSourceConnectorKind } from "./source-config";
+
+const initialState = createInitialAdminActionState<{ sourceId: string }>();
+
+interface RegisteredSourceFormProps {
+  defaultValues: {
+    description: string;
+    isEnabled: boolean;
+    name: string;
+    range: string;
+    sheetName: string;
+    sourceId?: string;
+    spreadsheetId: string;
+  };
+  mode: "create" | "edit";
+}
+
+export const RegisteredSourceForm = ({
+  defaultValues,
+  mode,
+}: RegisteredSourceFormProps) => {
+  const [state, formAction, isPending] = useActionState(
+    saveRegisteredSourceAction,
+    initialState
+  );
+  let submitLabel = "Save source";
+
+  if (mode === "create") {
+    submitLabel = "Create source";
+  }
+
+  if (isPending) {
+    submitLabel = mode === "create" ? "Creating..." : "Saving...";
+  }
+
+  return (
+    <form action={formAction} className="grid gap-4">
+      <input
+        name="connectorKind"
+        type="hidden"
+        value={registeredSourceConnectorKind.googleSheets}
+      />
+      {defaultValues.sourceId ? (
+        <input name="sourceId" type="hidden" value={defaultValues.sourceId} />
+      ) : null}
+      <label className="grid gap-2" htmlFor={`${mode}-source-name`}>
+        <span className="font-medium text-sm">Source name</span>
+        <Input
+          defaultValue={defaultValues.name}
+          id={`${mode}-source-name`}
+          name="name"
+          placeholder="Phase A Google Sheet"
+          required
+        />
+      </label>
+      <label className="grid gap-2" htmlFor={`${mode}-source-description`}>
+        <span className="font-medium text-sm">Description</span>
+        <Textarea
+          defaultValue={defaultValues.description}
+          id={`${mode}-source-description`}
+          name="description"
+          placeholder="Initial Google Sheets source used for admin ingestion scaffolding."
+          rows={3}
+        />
+      </label>
+      <div className="grid gap-3 md:grid-cols-2">
+        <label className="grid gap-2" htmlFor={`${mode}-source-spreadsheet`}>
+          <span className="font-medium text-sm">Spreadsheet ID</span>
+          <Input
+            defaultValue={defaultValues.spreadsheetId}
+            id={`${mode}-source-spreadsheet`}
+            name="spreadsheetId"
+            placeholder="1AbCdEfGhIjKlMnOpQrStUvWxYz"
+            required
+          />
+        </label>
+        <label className="grid gap-2" htmlFor={`${mode}-source-sheet`}>
+          <span className="font-medium text-sm">Sheet name</span>
+          <Input
+            defaultValue={defaultValues.sheetName}
+            id={`${mode}-source-sheet`}
+            name="sheetName"
+            placeholder="Sheet1"
+            required
+          />
+        </label>
+      </div>
+      <div className="grid gap-3 md:grid-cols-2">
+        <label className="grid gap-2" htmlFor={`${mode}-source-range`}>
+          <span className="font-medium text-sm">Bounded A1 range</span>
+          <Input
+            defaultValue={defaultValues.range}
+            id={`${mode}-source-range`}
+            name="range"
+            placeholder="A1:Z200"
+            required
+          />
+        </label>
+        <label className="grid gap-2" htmlFor={`${mode}-source-enabled`}>
+          <span className="font-medium text-sm">State</span>
+          <Select
+            defaultValue={defaultValues.isEnabled ? "true" : "false"}
+            id={`${mode}-source-enabled`}
+            name="isEnabled"
+          >
+            <option value="true">Enabled</option>
+            <option value="false">Disabled</option>
+          </Select>
+        </label>
+      </div>
+      <div className="rounded-lg border bg-muted/20 px-4 py-3 text-muted-foreground text-sm">
+        Registration stores only non-secret metadata. Google credentials remain
+        in server-side environment variables.
+      </div>
+      {state.message ? (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 text-destructive text-sm">
+          {state.message}
+        </div>
+      ) : null}
+      <Button disabled={isPending} type="submit">
+        {submitLabel}
+      </Button>
+    </form>
+  );
+};

--- a/src/features/admin/overview/page.tsx
+++ b/src/features/admin/overview/page.tsx
@@ -60,10 +60,16 @@ const quickLinks = [
     title: "APIs",
   },
   {
-    description: "Bounded placeholder for future operational oversight.",
+    description: "Register sources and trigger bounded ingestion reads.",
+    href: routes.adminIngestionRuns,
+    icon: FolderKanban,
+    title: "Ingestion Runs",
+  },
+  {
+    description: "Inspect deferred downstream scaffold history.",
     href: routes.adminPipelineRuns,
     icon: FolderKanban,
-    title: "Operations",
+    title: "Pipeline Runs",
   },
 ] as const;
 
@@ -81,7 +87,7 @@ export const AdminDashboardPageView = ({
 }: AdminDashboardSummary) => {
   return (
     <AdminModuleShell
-      description="Operational overview for user administration, invite posture, dataset visibility, and version activation."
+      description="Operational overview for user administration, invite posture, dataset visibility, ingestion scaffolding, and version activation."
       route={routes.adminHome}
       title="Overview"
     >

--- a/src/features/admin/publishing/page.tsx
+++ b/src/features/admin/publishing/page.tsx
@@ -26,8 +26,14 @@ import type { AdminPublishingPageData } from "@/features/admin/publishing/server
 import type {
   AdminDatasetVersionEventRecord,
   AdminDatasetVersionRecord,
+  AdminPublishRunRecord,
+  OperationRunStatus,
 } from "@/features/admin/shared";
-import { formatAdminDateTime, visibilityLabel } from "@/features/admin/shared";
+import {
+  formatAdminDateTime,
+  operationRunStatusLabel,
+  visibilityLabel,
+} from "@/features/admin/shared";
 import { AdminModuleShell } from "@/features/admin/ui/admin-module-shell";
 import { ConfirmSubmitButton } from "@/features/admin/ui/confirm-submit-button";
 import { routes } from "@/lib/routes";
@@ -38,6 +44,13 @@ const visibilityBadgeClassName = {
   shared: "border-blue-200 bg-blue-50 text-blue-700",
   workspace: "border-orange-200 bg-orange-50 text-orange-700",
 } as const;
+
+const operationStatusBadgeClassName: Record<OperationRunStatus, string> = {
+  failed: "border-red-200 bg-red-50 text-red-700",
+  queued: "border-zinc-200 bg-zinc-100 text-zinc-700",
+  running: "border-blue-200 bg-blue-50 text-blue-700",
+  succeeded: "border-emerald-200 bg-emerald-50 text-emerald-700",
+};
 
 const formatRowCountDelta = (value: number): string => {
   if (value === 0) {
@@ -51,6 +64,20 @@ const formatRowCountDelta = (value: number): string => {
 
 const formatEventTypeLabel = (eventType: string): string => {
   return eventType === "published" ? "Published" : "Activated";
+};
+
+const formatPublishActionTypeLabel = (actionType: string): string => {
+  return actionType === "activate_dataset_version"
+    ? "Activate dataset version"
+    : actionType;
+};
+
+const PublishRunStatusBadge = ({ status }: { status: OperationRunStatus }) => {
+  return (
+    <Badge className={operationStatusBadgeClassName[status]}>
+      {operationRunStatusLabel[status]}
+    </Badge>
+  );
 };
 
 const buildPublishingHref = (datasetId: string, versionId?: string): string => {
@@ -185,6 +212,62 @@ const VersionEventHistoryTable = ({
   );
 };
 
+const PublishingOperationsTable = ({
+  publishRuns,
+}: {
+  publishRuns: AdminPublishRunRecord[];
+}) => {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>When</TableHead>
+          <TableHead>Action</TableHead>
+          <TableHead>Version</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Operator</TableHead>
+          <TableHead>Notes</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {publishRuns.length === 0 ? (
+          <TableRow>
+            <TableCell className="text-muted-foreground" colSpan={6}>
+              No publishing operation wrappers have been recorded for this
+              dataset yet.
+            </TableCell>
+          </TableRow>
+        ) : null}
+        {publishRuns.map((run) => (
+          <TableRow key={run.id}>
+            <TableCell>{formatAdminDateTime(run.createdAt)}</TableCell>
+            <TableCell>
+              {formatPublishActionTypeLabel(run.actionType)}
+            </TableCell>
+            <TableCell>v{run.datasetVersionNumber ?? "?"}</TableCell>
+            <TableCell>
+              <PublishRunStatusBadge status={run.status} />
+            </TableCell>
+            <TableCell>
+              <div className="space-y-1">
+                <p>{run.requestedByDisplayName ?? "Unknown operator"}</p>
+                <p className="text-muted-foreground text-xs">
+                  {run.requestedByEmail ?? "Email unavailable"}
+                </p>
+              </div>
+            </TableCell>
+            <TableCell className="text-muted-foreground text-xs">
+              {run.errorMessage
+                ? run.errorMessage
+                : "Operational wrapper only. Domain publish history remains in dataset version events."}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};
+
 const AdminPublishingVersionRow = ({
   datasetId,
   selectedVersionId,
@@ -279,6 +362,7 @@ const AdminPublishingVersionRow = ({
 
 export const AdminPublishingPageView = ({
   datasets,
+  publishRuns,
   selectedDataset,
   selectedDatasetId,
   selectedVersion,
@@ -544,6 +628,19 @@ export const AdminPublishingPageView = ({
               </CardHeader>
               <CardContent>
                 <VersionEventHistoryTable events={versionEvents} />
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Publishing operations</CardTitle>
+                <CardDescription>
+                  Operational wrapper history around the existing activation
+                  flow. The authoritative domain history remains in dataset
+                  version events.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <PublishingOperationsTable publishRuns={publishRuns} />
               </CardContent>
             </Card>
             <Card>

--- a/src/features/admin/publishing/server.ts
+++ b/src/features/admin/publishing/server.ts
@@ -8,12 +8,14 @@ import {
   listAdminAuthUsers,
   listAdminDatasetVersionEvents,
   listAdminProfiles,
+  listAdminPublishRuns,
 } from "@/features/admin/server";
 import type {
   AdminDatasetRecord,
   AdminDatasetVersionEventRecord,
   AdminDatasetVersionRecord,
   AdminPublishingSelectedVersion,
+  AdminPublishRunRecord,
 } from "@/features/admin/shared";
 import {
   buildDatasetVersionComparisonSummary,
@@ -28,6 +30,7 @@ import { requireCurrentUserAdmin } from "@/lib/auth/server";
 
 export interface AdminPublishingPageData {
   datasets: AdminDatasetRecord[];
+  publishRuns: AdminPublishRunRecord[];
   selectedDataset: AdminDatasetRecord | null;
   selectedDatasetId: string | null;
   selectedVersion: AdminPublishingSelectedVersion | null;
@@ -98,10 +101,11 @@ export const loadAdminPublishingPage = async (
 ): Promise<AdminPublishingPageData> => {
   await requireCurrentUserAdmin();
   const inventory = await loadAdminDatasetInventory();
-  const [profiles, authUsers, versionEvents] = await Promise.all([
+  const [profiles, authUsers, versionEvents, publishRuns] = await Promise.all([
     listAdminProfiles(),
     listAdminAuthUsers(),
     listAdminDatasetVersionEvents(),
+    listAdminPublishRuns(),
   ]);
   const profileById = new Map(
     profiles.map((profile) => [profile.user_id, profile] as const)
@@ -307,9 +311,40 @@ export const loadAdminPublishingPage = async (
           } satisfies AdminDatasetVersionEventRecord;
         })
     : [];
+  const filteredPublishRuns = selectedDataset
+    ? publishRuns
+        .filter((run) => run.dataset_id === selectedDataset.id)
+        .map((run) => {
+          const actorProfile = run.requested_by
+            ? profileById.get(run.requested_by)
+            : undefined;
+          const actorAuthUser = run.requested_by
+            ? authUsers.usersById.get(run.requested_by)
+            : undefined;
+          const version = rawVersionsById.get(run.dataset_version_id);
+
+          return {
+            actionType: run.action_type,
+            completedAt: run.completed_at,
+            createdAt: run.created_at,
+            datasetId: run.dataset_id,
+            datasetName: selectedDataset.name,
+            datasetVersionId: run.dataset_version_id,
+            datasetVersionNumber: version?.version_number ?? null,
+            errorMessage: run.error_message,
+            id: run.id,
+            requestedByDisplayName: actorProfile?.display_name ?? null,
+            requestedByEmail: actorAuthUser?.email ?? null,
+            requestedByUserId: run.requested_by,
+            startedAt: run.started_at,
+            status: run.status,
+          } satisfies AdminPublishRunRecord;
+        })
+    : [];
 
   return {
     datasets: inventory.datasets,
+    publishRuns: filteredPublishRuns,
     selectedDataset,
     selectedDatasetId,
     selectedVersion,

--- a/src/features/admin/server.ts
+++ b/src/features/admin/server.ts
@@ -15,6 +15,23 @@ const workspaceMembershipSelect = "workspace_id, user_id, role, created_at";
 const inviteSelect =
   "id, email, status, expires_at, accepted_at, created_by, created_at, updated_at";
 
+const registeredSourceSelect =
+  "id, slug, name, description, connector_kind, is_enabled, config, " +
+  "last_run_at, last_run_status, created_by, created_at, updated_at";
+
+const ingestionRunSelect =
+  "id, source_id, run_kind, status, requested_by, started_at, completed_at, " +
+  "error_message, source_config_snapshot, metadata, created_at, updated_at";
+
+const pipelineRunSelect =
+  "id, source_id, ingestion_run_id, pipeline_key, execution_mode, status, " +
+  "requested_by, started_at, completed_at, error_message, metadata, " +
+  "created_at, updated_at";
+
+const publishRunSelect =
+  "id, dataset_id, dataset_version_id, action_type, status, requested_by, " +
+  "started_at, completed_at, error_message, metadata, created_at, updated_at";
+
 const datasetSelect =
   "id, slug, name, description, visibility, is_default_global, owner_workspace_id, active_version_id, metadata, created_at, updated_at";
 
@@ -109,6 +126,78 @@ export const listAdminInvites = async (): Promise<Tables<"invites">[]> => {
   }
 
   return (data ?? []) as Tables<"invites">[];
+};
+
+export const listAdminRegisteredSources = async (): Promise<
+  Tables<"registered_sources">[]
+> => {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("registered_sources")
+    .select(registeredSourceSelect)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(
+      toErrorMessage("Failed to load registered sources", error.message)
+    );
+  }
+
+  return (data ?? []) as unknown as Tables<"registered_sources">[];
+};
+
+export const listAdminIngestionRuns = async (): Promise<
+  Tables<"ingestion_runs">[]
+> => {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("ingestion_runs")
+    .select(ingestionRunSelect)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(
+      toErrorMessage("Failed to load ingestion runs", error.message)
+    );
+  }
+
+  return (data ?? []) as unknown as Tables<"ingestion_runs">[];
+};
+
+export const listAdminPipelineRuns = async (): Promise<
+  Tables<"pipeline_runs">[]
+> => {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("pipeline_runs")
+    .select(pipelineRunSelect)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(
+      toErrorMessage("Failed to load pipeline runs", error.message)
+    );
+  }
+
+  return (data ?? []) as unknown as Tables<"pipeline_runs">[];
+};
+
+export const listAdminPublishRuns = async (): Promise<
+  Tables<"publish_runs">[]
+> => {
+  const supabase = createAdminClient();
+  const { data, error } = await supabase
+    .from("publish_runs")
+    .select(publishRunSelect)
+    .order("created_at", { ascending: false });
+
+  if (error) {
+    throw new Error(
+      toErrorMessage("Failed to load publishing operations", error.message)
+    );
+  }
+
+  return (data ?? []) as unknown as Tables<"publish_runs">[];
 };
 
 export const listAdminDatasets = async (): Promise<Tables<"datasets">[]> => {

--- a/src/features/admin/shared.ts
+++ b/src/features/admin/shared.ts
@@ -10,6 +10,7 @@ export type AdminActionStatus = "error" | "idle" | "success";
 export type AppRole = Enums<"app_role">;
 export type DatasetVisibility = Enums<"dataset_visibility">;
 export type InviteStatus = Enums<"invite_status">;
+export type OperationRunStatus = Enums<"operation_run_status">;
 export type WorkspaceMemberRole = Enums<"workspace_member_role">;
 
 export interface AdminActionState<TData = null> {
@@ -160,11 +161,74 @@ export interface AdminDashboardSummary {
   workspaceDatasetCount: number;
 }
 
-export interface AdminOversightStatus {
-  description: string;
-  integrationNotes: string[];
-  key: "apis" | "ingestion-runs" | "pipeline-runs";
-  title: string;
+export interface AdminRegisteredSourceRecord {
+  connectorKind: string;
+  createdAt: string;
+  description: string | null;
+  id: string;
+  ingestionRunCount: number;
+  isEnabled: boolean;
+  lastIngestionRunId: string | null;
+  lastRunAt: string | null;
+  lastRunStatus: OperationRunStatus | null;
+  name: string;
+  pipelineRunCount: number;
+  range: string;
+  sheetName: string;
+  slug: string;
+  spreadsheetId: string;
+  updatedAt: string;
+}
+
+export interface AdminIngestionRunRecord {
+  completedAt: string | null;
+  createdAt: string;
+  errorMessage: string | null;
+  id: string;
+  requestedByDisplayName: string | null;
+  requestedByEmail: string | null;
+  requestedByUserId: string | null;
+  runKind: string;
+  sourceId: string;
+  sourceName: string;
+  sourceSlug: string;
+  startedAt: string | null;
+  status: OperationRunStatus;
+}
+
+export interface AdminPipelineRunRecord {
+  completedAt: string | null;
+  createdAt: string;
+  errorMessage: string | null;
+  executionMode: string;
+  id: string;
+  ingestionRunId: string | null;
+  pipelineKey: string;
+  requestedByDisplayName: string | null;
+  requestedByEmail: string | null;
+  requestedByUserId: string | null;
+  sourceId: string;
+  sourceName: string;
+  sourceSlug: string;
+  startedAt: string | null;
+  status: OperationRunStatus;
+}
+
+export interface AdminPublishRunRecord {
+  actionType: string;
+  completedAt: string | null;
+  createdAt: string;
+  datasetId: string;
+  datasetName: string;
+  datasetVersionId: string;
+  datasetVersionNumber: number | null;
+  errorMessage: string | null;
+  id: string;
+  requestedByDisplayName: string | null;
+  requestedByEmail: string | null;
+  requestedByUserId: string | null;
+  startedAt: string | null;
+  status: OperationRunStatus;
 }
 
 export const createInitialAdminActionState = <
@@ -226,6 +290,13 @@ export const visibilityLabel: Record<DatasetVisibility, string> = {
 export const appRoleLabel: Record<AppRole, string> = {
   admin: "Admin",
   user: "User",
+};
+
+export const operationRunStatusLabel: Record<OperationRunStatus, string> = {
+  failed: "Failed",
+  queued: "Queued",
+  running: "Running",
+  succeeded: "Succeeded",
 };
 
 export const getDatasetAccessRuleCopy = (

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -23,6 +23,9 @@ const appUrlSchema = requiredString("NEXT_PUBLIC_APP_URL").url(
   "NEXT_PUBLIC_APP_URL must be a valid URL."
 );
 const serviceRoleKeySchema = requiredString("SUPABASE_SERVICE_ROLE_KEY");
+const googleServiceAccountJsonSchema = requiredString(
+  "GOOGLE_SERVICE_ACCOUNT_JSON"
+);
 
 const formatEnvError = (
   runtime: "client" | "server",
@@ -160,6 +163,12 @@ export const getAppUrl = (): string => {
 
 export const getSupabaseServiceRoleKey = (): string => {
   return serviceRoleKeySchema.parse(process.env.SUPABASE_SERVICE_ROLE_KEY);
+};
+
+export const getGoogleServiceAccountJson = (): string => {
+  return googleServiceAccountJsonSchema.parse(
+    process.env.GOOGLE_SERVICE_ACCOUNT_JSON
+  );
 };
 
 export const validateEnv = (): void => {

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -335,6 +335,122 @@ export interface Database {
         };
         Relationships: [];
       };
+      ingestion_runs: {
+        Row: {
+          completed_at: string | null;
+          created_at: string;
+          error_message: string | null;
+          id: string;
+          metadata: Json;
+          requested_by: string | null;
+          run_kind: string;
+          source_config_snapshot: Json;
+          source_id: string;
+          started_at: string | null;
+          status: Database["public"]["Enums"]["operation_run_status"];
+          updated_at: string;
+        };
+        Insert: {
+          completed_at?: string | null;
+          created_at?: string;
+          error_message?: string | null;
+          id?: string;
+          metadata?: Json;
+          requested_by?: string | null;
+          run_kind: string;
+          source_config_snapshot?: Json;
+          source_id: string;
+          started_at?: string | null;
+          status?: Database["public"]["Enums"]["operation_run_status"];
+          updated_at?: string;
+        };
+        Update: {
+          completed_at?: string | null;
+          created_at?: string;
+          error_message?: string | null;
+          id?: string;
+          metadata?: Json;
+          requested_by?: string | null;
+          run_kind?: string;
+          source_config_snapshot?: Json;
+          source_id?: string;
+          started_at?: string | null;
+          status?: Database["public"]["Enums"]["operation_run_status"];
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "ingestion_runs_source_id_fkey";
+            columns: ["source_id"];
+            isOneToOne: false;
+            referencedRelation: "registered_sources";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      pipeline_runs: {
+        Row: {
+          completed_at: string | null;
+          created_at: string;
+          error_message: string | null;
+          execution_mode: string;
+          id: string;
+          ingestion_run_id: string | null;
+          metadata: Json;
+          pipeline_key: string;
+          requested_by: string | null;
+          source_id: string;
+          started_at: string | null;
+          status: Database["public"]["Enums"]["operation_run_status"];
+          updated_at: string;
+        };
+        Insert: {
+          completed_at?: string | null;
+          created_at?: string;
+          error_message?: string | null;
+          execution_mode: string;
+          id?: string;
+          ingestion_run_id?: string | null;
+          metadata?: Json;
+          pipeline_key: string;
+          requested_by?: string | null;
+          source_id: string;
+          started_at?: string | null;
+          status?: Database["public"]["Enums"]["operation_run_status"];
+          updated_at?: string;
+        };
+        Update: {
+          completed_at?: string | null;
+          created_at?: string;
+          error_message?: string | null;
+          execution_mode?: string;
+          id?: string;
+          ingestion_run_id?: string | null;
+          metadata?: Json;
+          pipeline_key?: string;
+          requested_by?: string | null;
+          source_id?: string;
+          started_at?: string | null;
+          status?: Database["public"]["Enums"]["operation_run_status"];
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "pipeline_runs_ingestion_run_id_fkey";
+            columns: ["ingestion_run_id"];
+            isOneToOne: false;
+            referencedRelation: "ingestion_runs";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "pipeline_runs_source_id_fkey";
+            columns: ["source_id"];
+            isOneToOne: false;
+            referencedRelation: "registered_sources";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       profiles: {
         Row: {
           app_role: Database["public"]["Enums"]["app_role"];
@@ -359,6 +475,117 @@ export interface Database {
           display_name?: string | null;
           updated_at?: string;
           user_id?: string;
+        };
+        Relationships: [];
+      };
+      publish_runs: {
+        Row: {
+          action_type: string;
+          completed_at: string | null;
+          created_at: string;
+          dataset_id: string;
+          dataset_version_id: string;
+          error_message: string | null;
+          id: string;
+          metadata: Json;
+          requested_by: string | null;
+          started_at: string | null;
+          status: Database["public"]["Enums"]["operation_run_status"];
+          updated_at: string;
+        };
+        Insert: {
+          action_type: string;
+          completed_at?: string | null;
+          created_at?: string;
+          dataset_id: string;
+          dataset_version_id: string;
+          error_message?: string | null;
+          id?: string;
+          metadata?: Json;
+          requested_by?: string | null;
+          started_at?: string | null;
+          status?: Database["public"]["Enums"]["operation_run_status"];
+          updated_at?: string;
+        };
+        Update: {
+          action_type?: string;
+          completed_at?: string | null;
+          created_at?: string;
+          dataset_id?: string;
+          dataset_version_id?: string;
+          error_message?: string | null;
+          id?: string;
+          metadata?: Json;
+          requested_by?: string | null;
+          started_at?: string | null;
+          status?: Database["public"]["Enums"]["operation_run_status"];
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "publish_runs_dataset_id_fkey";
+            columns: ["dataset_id"];
+            isOneToOne: false;
+            referencedRelation: "datasets";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "publish_runs_dataset_version_id_fkey";
+            columns: ["dataset_version_id"];
+            isOneToOne: false;
+            referencedRelation: "dataset_versions";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      registered_sources: {
+        Row: {
+          config: Json;
+          connector_kind: string;
+          created_at: string;
+          created_by: string | null;
+          description: string | null;
+          id: string;
+          is_enabled: boolean;
+          last_run_at: string | null;
+          last_run_status:
+            | Database["public"]["Enums"]["operation_run_status"]
+            | null;
+          name: string;
+          slug: string;
+          updated_at: string;
+        };
+        Insert: {
+          config?: Json;
+          connector_kind: string;
+          created_at?: string;
+          created_by?: string | null;
+          description?: string | null;
+          id?: string;
+          is_enabled?: boolean;
+          last_run_at?: string | null;
+          last_run_status?:
+            | Database["public"]["Enums"]["operation_run_status"]
+            | null;
+          name: string;
+          slug: string;
+          updated_at?: string;
+        };
+        Update: {
+          config?: Json;
+          connector_kind?: string;
+          created_at?: string;
+          created_by?: string | null;
+          description?: string | null;
+          id?: string;
+          is_enabled?: boolean;
+          last_run_at?: string | null;
+          last_run_status?:
+            | Database["public"]["Enums"]["operation_run_status"]
+            | null;
+          name?: string;
+          slug?: string;
+          updated_at?: string;
         };
         Relationships: [];
       };
@@ -467,6 +694,7 @@ export interface Database {
       app_role: "user" | "admin";
       dataset_visibility: "global" | "private" | "workspace" | "shared";
       invite_status: "pending" | "accepted" | "revoked" | "expired";
+      operation_run_status: "queued" | "running" | "succeeded" | "failed";
       workspace_member_role: "owner" | "admin" | "member";
     };
     CompositeTypes: {
@@ -601,6 +829,7 @@ export const Constants = {
       app_role: ["user", "admin"],
       dataset_visibility: ["global", "private", "workspace", "shared"],
       invite_status: ["pending", "accepted", "revoked", "expired"],
+      operation_run_status: ["queued", "running", "succeeded", "failed"],
       workspace_member_role: ["owner", "admin", "member"],
     },
   },

--- a/supabase/migrations/20260402090000_phase_b_admin_operations_foundation.sql
+++ b/supabase/migrations/20260402090000_phase_b_admin_operations_foundation.sql
@@ -1,0 +1,185 @@
+create type public.operation_run_status as enum (
+  'queued',
+  'running',
+  'succeeded',
+  'failed'
+);
+
+create table public.registered_sources (
+  id uuid primary key default gen_random_uuid(),
+  slug text not null unique,
+  name text not null,
+  description text null,
+  connector_kind text not null,
+  is_enabled boolean not null default true,
+  config jsonb not null default '{}'::jsonb,
+  last_run_at timestamptz null,
+  last_run_status public.operation_run_status null,
+  created_by uuid null references auth.users (id) on delete set null,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint registered_sources_config_object_check check (
+    jsonb_typeof(config) = 'object'
+  )
+);
+
+create index registered_sources_connector_kind_idx
+  on public.registered_sources (connector_kind);
+
+create table public.ingestion_runs (
+  id uuid primary key default gen_random_uuid(),
+  source_id uuid not null references public.registered_sources (id) on delete cascade,
+  run_kind text not null,
+  status public.operation_run_status not null default 'queued',
+  requested_by uuid null references auth.users (id) on delete set null,
+  started_at timestamptz null,
+  completed_at timestamptz null,
+  error_message text null,
+  source_config_snapshot jsonb not null default '{}'::jsonb,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint ingestion_runs_run_kind_required check (char_length(run_kind) > 0),
+  constraint ingestion_runs_completed_after_started check (
+    completed_at is null
+    or started_at is null
+    or completed_at >= started_at
+  ),
+  constraint ingestion_runs_snapshot_object_check check (
+    jsonb_typeof(source_config_snapshot) = 'object'
+  ),
+  constraint ingestion_runs_metadata_object_check check (
+    jsonb_typeof(metadata) = 'object'
+  )
+);
+
+create index ingestion_runs_source_id_created_at_idx
+  on public.ingestion_runs (source_id, created_at desc);
+
+create index ingestion_runs_status_created_at_idx
+  on public.ingestion_runs (status, created_at desc);
+
+create table public.pipeline_runs (
+  id uuid primary key default gen_random_uuid(),
+  source_id uuid not null references public.registered_sources (id) on delete cascade,
+  ingestion_run_id uuid null references public.ingestion_runs (id) on delete set null,
+  pipeline_key text not null,
+  execution_mode text not null,
+  status public.operation_run_status not null default 'queued',
+  requested_by uuid null references auth.users (id) on delete set null,
+  started_at timestamptz null,
+  completed_at timestamptz null,
+  error_message text null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint pipeline_runs_pipeline_key_required check (
+    char_length(pipeline_key) > 0
+  ),
+  constraint pipeline_runs_execution_mode_phase_b_check check (
+    execution_mode = 'deferred_scaffold'
+  ),
+  constraint pipeline_runs_completed_after_started check (
+    completed_at is null
+    or started_at is null
+    or completed_at >= started_at
+  ),
+  constraint pipeline_runs_metadata_object_check check (
+    jsonb_typeof(metadata) = 'object'
+  )
+);
+
+create index pipeline_runs_source_id_created_at_idx
+  on public.pipeline_runs (source_id, created_at desc);
+
+create index pipeline_runs_ingestion_run_id_idx
+  on public.pipeline_runs (ingestion_run_id);
+
+create index pipeline_runs_status_created_at_idx
+  on public.pipeline_runs (status, created_at desc);
+
+create table public.publish_runs (
+  id uuid primary key default gen_random_uuid(),
+  dataset_id uuid not null references public.datasets (id) on delete cascade,
+  dataset_version_id uuid not null references public.dataset_versions (id) on delete cascade,
+  action_type text not null,
+  status public.operation_run_status not null default 'queued',
+  requested_by uuid null references auth.users (id) on delete set null,
+  started_at timestamptz null,
+  completed_at timestamptz null,
+  error_message text null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  constraint publish_runs_action_type_required check (
+    char_length(action_type) > 0
+  ),
+  constraint publish_runs_completed_after_started check (
+    completed_at is null
+    or started_at is null
+    or completed_at >= started_at
+  ),
+  constraint publish_runs_metadata_object_check check (
+    jsonb_typeof(metadata) = 'object'
+  )
+);
+
+create index publish_runs_dataset_id_created_at_idx
+  on public.publish_runs (dataset_id, created_at desc);
+
+create index publish_runs_dataset_version_id_created_at_idx
+  on public.publish_runs (dataset_version_id, created_at desc);
+
+create index publish_runs_status_created_at_idx
+  on public.publish_runs (status, created_at desc);
+
+create trigger set_registered_sources_updated_at
+before update on public.registered_sources
+for each row
+execute function public.set_updated_at();
+
+create trigger set_ingestion_runs_updated_at
+before update on public.ingestion_runs
+for each row
+execute function public.set_updated_at();
+
+create trigger set_pipeline_runs_updated_at
+before update on public.pipeline_runs
+for each row
+execute function public.set_updated_at();
+
+create trigger set_publish_runs_updated_at
+before update on public.publish_runs
+for each row
+execute function public.set_updated_at();
+
+alter table public.registered_sources enable row level security;
+alter table public.ingestion_runs enable row level security;
+alter table public.pipeline_runs enable row level security;
+alter table public.publish_runs enable row level security;
+
+revoke all on table public.registered_sources from anon;
+revoke all on table public.ingestion_runs from anon;
+revoke all on table public.pipeline_runs from anon;
+revoke all on table public.publish_runs from anon;
+
+revoke all on table public.registered_sources from authenticated;
+revoke all on table public.ingestion_runs from authenticated;
+revoke all on table public.pipeline_runs from authenticated;
+revoke all on table public.publish_runs from authenticated;
+
+grant select, insert, update, delete
+on table public.registered_sources
+to service_role;
+
+grant select, insert, update, delete
+on table public.ingestion_runs
+to service_role;
+
+grant select, insert, update, delete
+on table public.pipeline_runs
+to service_role;
+
+grant select, insert, update, delete
+on table public.publish_runs
+to service_role;

--- a/tests/admin-operations.spec.ts
+++ b/tests/admin-operations.spec.ts
@@ -1,0 +1,656 @@
+import { existsSync, readFileSync } from "node:fs";
+
+import { expect, type Page, test } from "@playwright/test";
+import { createClient } from "@supabase/supabase-js";
+
+import type { Database, Json } from "@/lib/supabase/database.types";
+
+const envLinePattern = /\r?\n/u;
+const envNamePattern = /^[A-Za-z_][A-Za-z0-9_]*$/u;
+
+const normalizeEnvValue = (value: string): string => {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+
+  return value;
+};
+
+const parseEnvAssignment = (
+  rawLine: string
+): { value: string; variableName: string } | null => {
+  const trimmedLine = rawLine.trim();
+
+  if (!trimmedLine || trimmedLine.startsWith("#")) {
+    return null;
+  }
+
+  const separatorIndex = rawLine.indexOf("=");
+
+  if (separatorIndex <= 0) {
+    return null;
+  }
+
+  const variableName = rawLine.slice(0, separatorIndex).trim();
+
+  if (!envNamePattern.test(variableName)) {
+    return null;
+  }
+
+  return {
+    value: normalizeEnvValue(rawLine.slice(separatorIndex + 1).trim()),
+    variableName,
+  };
+};
+
+const loadLocalEnvFiles = (): void => {
+  for (const filename of [".env.local", ".env.test.local"]) {
+    if (!existsSync(filename)) {
+      continue;
+    }
+
+    const fileContents = readFileSync(filename, "utf8");
+
+    for (const rawLine of fileContents.split(envLinePattern)) {
+      const parsedAssignment = parseEnvAssignment(rawLine);
+
+      if (!parsedAssignment) {
+        continue;
+      }
+
+      if (process.env[parsedAssignment.variableName]?.trim()) {
+        continue;
+      }
+
+      process.env[parsedAssignment.variableName] = parsedAssignment.value;
+    }
+  }
+};
+
+loadLocalEnvFiles();
+
+const defaultValidationSourceSlug = "phaseb-prod-validation-google-sheet";
+const localAdminCredentials = {
+  email: "admin@accelerate.test",
+  password: "password123",
+};
+const runIdPattern = /runId=/;
+const hostedValidationEnabled =
+  process.env.PLAYWRIGHT_DISABLE_WEBSERVER === "true";
+
+interface HostedValidationSource {
+  id: string;
+  name: string;
+  range: string;
+  slug: string;
+}
+
+interface HostedRunExpectations {
+  expectedDataRowCount: number;
+  expectedRange: string;
+  expectedSampleText: string;
+}
+
+const getFirstDefinedEnvValue = (...names: string[]): string | undefined => {
+  for (const name of names) {
+    const value = process.env[name]?.trim();
+
+    if (value) {
+      return value;
+    }
+  }
+
+  return undefined;
+};
+
+const getRequiredHostedEnv = (label: string, ...envNames: string[]): string => {
+  const value = getFirstDefinedEnvValue(...envNames);
+
+  if (value) {
+    return value;
+  }
+
+  throw new Error(`${label} is required for hosted Phase B validation.`);
+};
+
+const getOptionalEnv = (...envNames: string[]): string | undefined => {
+  return getFirstDefinedEnvValue(...envNames);
+};
+
+const getHostedAppUrl = (): string => {
+  return getRequiredHostedEnv(
+    "NEXT_PUBLIC_APP_URL",
+    "NEXT_PUBLIC_APP_URL",
+    "PLAYWRIGHT_BASE_URL"
+  );
+};
+
+const getAdminCredentials = () => {
+  if (!hostedValidationEnabled) {
+    return localAdminCredentials;
+  }
+
+  return {
+    email: getRequiredHostedEnv(
+      "PHASEB_ADMIN_EMAIL",
+      "PHASEB_ADMIN_EMAIL",
+      "PLAYWRIGHT_PHASEB_ADMIN_EMAIL"
+    ),
+    password: getRequiredHostedEnv(
+      "PHASEB_ADMIN_PASSWORD",
+      "PHASEB_ADMIN_PASSWORD",
+      "PLAYWRIGHT_PHASEB_ADMIN_PASSWORD"
+    ),
+  };
+};
+
+const getSupabaseUrl = (): string => {
+  if (!hostedValidationEnabled) {
+    return (
+      process.env.PLAYWRIGHT_NEXT_PUBLIC_SUPABASE_URL ??
+      process.env.NEXT_PUBLIC_SUPABASE_URL ??
+      "http://127.0.0.1:54321"
+    );
+  }
+
+  return getRequiredHostedEnv(
+    "NEXT_PUBLIC_SUPABASE_URL",
+    "NEXT_PUBLIC_SUPABASE_URL",
+    "PLAYWRIGHT_NEXT_PUBLIC_SUPABASE_URL"
+  );
+};
+
+const supabaseUrl = getSupabaseUrl();
+const supabaseAnonKey = hostedValidationEnabled
+  ? getRequiredHostedEnv(
+      "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+      "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+      "PLAYWRIGHT_NEXT_PUBLIC_SUPABASE_ANON_KEY"
+    )
+  : (process.env.PLAYWRIGHT_NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+    "sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH");
+
+const toBase64Url = (input: string) => {
+  return Buffer.from(input)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
+};
+
+const getPasswordSession = async (credentials: {
+  email: string;
+  password: string;
+}) => {
+  const response = await fetch(
+    `${supabaseUrl}/auth/v1/token?grant_type=password`,
+    {
+      body: JSON.stringify(credentials),
+      headers: {
+        apikey: supabaseAnonKey,
+        "content-type": "application/json",
+      },
+      method: "POST",
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Auth failed for ${credentials.email}: ${response.status} ${response.statusText}`
+    );
+  }
+
+  return response.json();
+};
+
+const getSupabaseSessionCookieName = (url: string): string => {
+  const hostname = new URL(url).hostname;
+  const storageKeySegment = hostname.split(".")[0];
+
+  if (!storageKeySegment) {
+    throw new Error("Could not derive the Supabase auth cookie name.");
+  }
+
+  return `sb-${storageKeySegment}-auth-token`;
+};
+
+const buildSessionCookieValue = (session: {
+  access_token: string;
+  expires_at: number;
+  expires_in: number;
+  refresh_token: string;
+  token_type: string;
+  user: unknown;
+}) => {
+  const payload = {
+    access_token: session.access_token,
+    expires_at: session.expires_at,
+    expires_in: session.expires_in,
+    refresh_token: session.refresh_token,
+    token_type: session.token_type,
+    user: session.user,
+  };
+
+  return `base64-${toBase64Url(JSON.stringify(payload))}`;
+};
+
+const createServiceClient = () => {
+  return createClient<Database>(
+    supabaseUrl,
+    getRequiredHostedEnv(
+      "SUPABASE_SERVICE_ROLE_KEY",
+      "SUPABASE_SERVICE_ROLE_KEY",
+      "PLAYWRIGHT_SUPABASE_SERVICE_ROLE_KEY"
+    ),
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    }
+  );
+};
+
+const isJsonRecord = (
+  value: Json | null | undefined | unknown
+): value is Record<string, Json | undefined> => {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+};
+
+const getJsonString = (
+  value: Json | null | undefined | unknown,
+  key: string
+): string | null => {
+  if (!isJsonRecord(value)) {
+    return null;
+  }
+
+  const propertyValue = value[key];
+
+  if (typeof propertyValue !== "string") {
+    return null;
+  }
+
+  const normalizedValue = propertyValue.trim();
+
+  return normalizedValue || null;
+};
+
+const getJsonNumber = (
+  value: Json | null | undefined | unknown,
+  key: string
+): number | null => {
+  if (!isJsonRecord(value)) {
+    return null;
+  }
+
+  const propertyValue = value[key];
+
+  if (typeof propertyValue !== "number" || !Number.isFinite(propertyValue)) {
+    return null;
+  }
+
+  return propertyValue;
+};
+
+const deriveExpectedSampleText = (
+  value: Json | null | undefined
+): string | null => {
+  if (!isJsonRecord(value)) {
+    return null;
+  }
+
+  const sampleRows = value.sampleRows;
+
+  if (!Array.isArray(sampleRows)) {
+    return null;
+  }
+
+  for (const row of sampleRows) {
+    if (!Array.isArray(row)) {
+      continue;
+    }
+
+    for (const cell of row) {
+      if (typeof cell !== "string") {
+        continue;
+      }
+
+      const normalizedValue = cell.trim();
+
+      if (normalizedValue) {
+        return normalizedValue;
+      }
+    }
+  }
+
+  return null;
+};
+
+const parseSourceRange = (value: Json | null | undefined): string | null => {
+  return getJsonString(value, "range");
+};
+
+const resolveHostedValidationSource =
+  async (): Promise<HostedValidationSource> => {
+    const validationSourceSlug =
+      getOptionalEnv("PHASEB_VALIDATION_SOURCE_SLUG") ??
+      defaultValidationSourceSlug;
+    const serviceClient = createServiceClient();
+    const { data, error } = await serviceClient
+      .from("registered_sources")
+      .select("id, slug, name, config, is_enabled")
+      .eq("slug", validationSourceSlug)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(`Failed to load validation source: ${error.message}`);
+    }
+
+    if (!data) {
+      throw new Error(
+        `Validation source slug "${validationSourceSlug}" was not found.`
+      );
+    }
+
+    if (!data.is_enabled) {
+      throw new Error(
+        `Validation source slug "${validationSourceSlug}" is disabled.`
+      );
+    }
+
+    const range =
+      getOptionalEnv("GOOGLE_WORKSPACE_SOURCE_RANGE") ??
+      parseSourceRange(data.config);
+
+    if (!range) {
+      throw new Error(
+        "Validation range could not be derived from GOOGLE_WORKSPACE_SOURCE_RANGE or the registered source config."
+      );
+    }
+
+    return {
+      id: data.id,
+      name: data.name,
+      range,
+      slug: data.slug,
+    };
+  };
+
+const waitForDeferredPipelineRunId = async ({
+  ingestionRunId,
+  sourceId,
+}: {
+  ingestionRunId: string;
+  sourceId: string;
+}): Promise<string> => {
+  const serviceClient = createServiceClient();
+
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const { data, error } = await serviceClient
+      .from("pipeline_runs")
+      .select("id")
+      .eq("execution_mode", "deferred_scaffold")
+      .eq("ingestion_run_id", ingestionRunId)
+      .eq("pipeline_key", "source_ingestion_scaffold")
+      .eq("source_id", sourceId)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(`Failed to load linked pipeline run: ${error.message}`);
+    }
+
+    if (data?.id) {
+      return data.id;
+    }
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1000);
+    });
+  }
+
+  throw new Error(
+    "Timed out waiting for the deferred pipeline scaffold row to appear."
+  );
+};
+
+const waitForHostedRunExpectations = async ({
+  runId,
+  source,
+}: {
+  runId: string;
+  source: HostedValidationSource;
+}): Promise<HostedRunExpectations> => {
+  const serviceClient = createServiceClient();
+
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const { data, error } = await serviceClient
+      .from("ingestion_runs")
+      .select(
+        "id, source_id, status, error_message, metadata, source_config_snapshot"
+      )
+      .eq("id", runId)
+      .eq("source_id", source.id)
+      .maybeSingle();
+
+    if (error) {
+      throw new Error(`Failed to load ingestion run details: ${error.message}`);
+    }
+
+    if (!data) {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1000);
+      });
+
+      continue;
+    }
+
+    if (data.status === "failed") {
+      throw new Error(
+        data.error_message || "Validation ingestion run failed unexpectedly."
+      );
+    }
+
+    if (data.status !== "succeeded") {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 1000);
+      });
+
+      continue;
+    }
+
+    const expectedDataRowCount = getJsonNumber(data.metadata, "dataRowCount");
+    const expectedSampleText = deriveExpectedSampleText(data.metadata);
+    const expectedRange =
+      getOptionalEnv("GOOGLE_WORKSPACE_SOURCE_RANGE") ??
+      parseSourceRange(data.source_config_snapshot) ??
+      source.range;
+
+    if (expectedDataRowCount === null) {
+      throw new Error(
+        "Validation run metadata did not include a usable data row count."
+      );
+    }
+
+    if (!expectedSampleText) {
+      throw new Error(
+        "Validation run metadata did not include a usable sample text value."
+      );
+    }
+
+    if (!expectedRange) {
+      throw new Error(
+        "Validation range could not be derived from the run metadata or source config."
+      );
+    }
+
+    return {
+      expectedDataRowCount,
+      expectedRange,
+      expectedSampleText,
+    };
+  }
+
+  throw new Error(
+    "Timed out waiting for the hosted ingestion run to complete successfully."
+  );
+};
+
+const runLocalFixtureProof = async ({ page }: { page: Page }) => {
+  const sourceName = `Phase A Google Sheet ${Date.now()}`;
+
+  await page.goto("/app/admin/ingestion-runs");
+  await expect(
+    page.getByRole("heading", { exact: true, name: "Ingestion Runs" })
+  ).toBeVisible();
+
+  await page.getByLabel("Source name").first().fill(sourceName);
+  await page
+    .getByLabel("Description")
+    .first()
+    .fill("Operational Phase B source registration test.");
+  await page.getByLabel("Spreadsheet ID").first().fill("phase-a-sheet-001");
+  await page.getByLabel("Sheet name").first().fill("PhaseA");
+  await page.getByLabel("Bounded A1 range").first().fill("A1:C10");
+  await page.getByRole("button", { name: "Create source" }).click();
+
+  await expect(page.getByText("Edit selected source")).toBeVisible();
+  await expect(page.getByText(sourceName)).toBeVisible();
+  await expect(page.getByRole("button", { name: "Run read" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Run read" }).click();
+  await page.waitForURL(runIdPattern);
+
+  await expect(page.getByText("Run details")).toBeVisible();
+  await expect(page.getByText("Playwright fixture")).toBeVisible();
+  await expect(page.getByText("Data rows after header: 3")).toBeVisible();
+  await expect(page.getByText("Stored sample rows")).toBeVisible();
+  await expect(page.getByText("Phase A Alpha")).toBeVisible();
+  await expect(page.getByText("Succeeded")).toBeVisible();
+
+  await page.goto("/app/admin/pipeline-runs");
+  await expect(
+    page.getByRole("heading", { exact: true, name: "Pipeline Runs" })
+  ).toBeVisible();
+  await expect(page.getByText("Deferred scaffold only")).toBeVisible();
+  await expect(page.getByText(sourceName)).toBeVisible();
+  await expect(
+    page.getByRole("cell", { name: "Deferred" }).first()
+  ).toBeVisible();
+};
+
+const runHostedProductionProof = async ({
+  page,
+  validationSource,
+}: {
+  page: Page;
+  validationSource: HostedValidationSource;
+}) => {
+  await page.goto(`/app/admin/ingestion-runs?sourceId=${validationSource.id}`);
+  await expect(
+    page.getByRole("heading", { exact: true, name: "Ingestion Runs" })
+  ).toBeVisible();
+  await expect(page.getByText(validationSource.name)).toBeVisible();
+
+  const runReadForm = page
+    .locator("form")
+    .filter({
+      has: page.locator(
+        `input[name="sourceId"][value="${validationSource.id}"]`
+      ),
+    })
+    .filter({
+      has: page.getByRole("button", { name: "Run read" }),
+    })
+    .first();
+  const runReadButton = runReadForm.getByRole("button", { name: "Run read" });
+
+  await expect(runReadButton).toBeEnabled();
+  await runReadButton.click();
+  await page.waitForURL(runIdPattern);
+
+  const runId = new URL(page.url()).searchParams.get("runId");
+
+  if (!runId) {
+    throw new Error("Could not determine the ingestion run id from the URL.");
+  }
+
+  const runExpectations = await waitForHostedRunExpectations({
+    runId,
+    source: validationSource,
+  });
+
+  await expect(page.getByText("Run details")).toBeVisible();
+  await expect(
+    page.getByText("Read mode: Live Google Sheets API")
+  ).toBeVisible();
+  await expect(
+    page.getByText(
+      `Data rows after header: ${runExpectations.expectedDataRowCount}`
+    )
+  ).toBeVisible();
+  await expect(
+    page.getByText(runExpectations.expectedSampleText)
+  ).toBeVisible();
+  await expect(
+    page.getByText(`Range: ${runExpectations.expectedRange}`)
+  ).toBeVisible();
+  await expect(page.getByText("Succeeded")).toBeVisible();
+
+  const pipelineRunId = await waitForDeferredPipelineRunId({
+    ingestionRunId: runId,
+    sourceId: validationSource.id,
+  });
+
+  await page.goto(
+    `/app/admin/pipeline-runs?sourceId=${validationSource.id}&runId=${pipelineRunId}`
+  );
+  await expect(
+    page.getByRole("heading", { exact: true, name: "Pipeline Runs" })
+  ).toBeVisible();
+  await expect(page.getByText("Deferred scaffold only")).toBeVisible();
+  await expect(
+    page.getByText("Execution mode: deferred_scaffold")
+  ).toBeVisible();
+  await expect(page.getByText("Deferred scaffold only: Yes")).toBeVisible();
+};
+
+test("admin can register a source, trigger a read, and inspect deferred pipeline scaffolding", async ({
+  page,
+  baseURL,
+  context,
+}) => {
+  const session = await getPasswordSession(getAdminCredentials());
+  const appUrl =
+    baseURL ??
+    (hostedValidationEnabled ? getHostedAppUrl() : "http://127.0.0.1:3000");
+
+  await context.addCookies([
+    {
+      httpOnly: false,
+      name: getSupabaseSessionCookieName(supabaseUrl),
+      sameSite: "Lax",
+      url: appUrl,
+      value: buildSessionCookieValue(session),
+    },
+  ]);
+
+  if (hostedValidationEnabled) {
+    const validationSource = await resolveHostedValidationSource();
+
+    await runHostedProductionProof({
+      page,
+      validationSource,
+    });
+
+    return;
+  }
+
+  await runLocalFixtureProof({
+    page,
+  });
+});


### PR DESCRIPTION
## What changed
- restore the Phase B admin operations implementation and supporting hosted schema migration
- add the Phase B production closeout validation docs and proof scripts
- update the hosted validation harness to derive source/run expectations and tighten the hosted Playwright assertions

## Why
Hosted Phase B work had been ported back into the local repo but was still only present as uncommitted local state. This PR moves the full restored implementation and closeout harness into the repository so `preview` becomes the source of truth again.

## Impact
- admin ingestion and pipeline run routes regain the restored Phase B operations flow
- hosted Supabase can be brought into line with the repo via the included migration
- the production closeout harness is available in-tree for the final hosted proof rerun

## Validation
- `npm run check`
- `npm run build`
