### PR TITLE
[codex] Fix Phase B hosted deployment env fallback

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -167,7 +167,10 @@ export const getSupabaseServiceRoleKey = (): string => {
 
 export const getGoogleServiceAccountJson = (): string => {
   return googleServiceAccountJsonSchema.parse(
-    process.env.GOOGLE_SERVICE_ACCOUNT_JSON
+    getFirstDefinedEnvValue(
+      process.env.GOOGLE_SERVICE_ACCOUNT_JSON,
+      process.env.GOOGLE_WORKSPACE_SERVICE_ACCOUNT_JSON
+    )
   );
 };
 

--- a/tests/admin-operations.spec.ts
+++ b/tests/admin-operations.spec.ts
@@ -554,7 +554,9 @@ const runHostedProductionProof = async ({
   await expect(
     page.getByRole("heading", { exact: true, name: "Ingestion Runs" })
   ).toBeVisible();
-  await expect(page.getByText(validationSource.name)).toBeVisible();
+  await expect(
+    page.getByText(validationSource.name, { exact: true })
+  ).toBeVisible();
 
   const runReadForm = page
     .locator("form")


### PR DESCRIPTION
## What changed
- allow the Phase B Google Sheets read path to fall back to `GOOGLE_WORKSPACE_SERVICE_ACCOUNT_JSON` when `GOOGLE_SERVICE_ACCOUNT_JSON` is absent in the hosted deployment
- tighten the hosted browser proof source-name assertion to exact text so it no longer collides with the surrounding description copy

## Why
The hosted Phase B backend is ready, and the production domain is now serving the restored Phase B UI. The remaining blocker was a deployment/env mismatch: the live app had the older workspace-prefixed Google service-account secret available, but the Phase B read path only accepted the newer env name. This PR keeps the current behavior and adds the bounded compatibility fallback needed for the final hosted closeout proof.

## Validation
- `npm run check`
- `npm run build`
