### PR TITLE
[codex] Fix Phase B ingestion metadata defaults

### DIFF
--- a/src/features/admin/operations/source-config.ts
+++ b/src/features/admin/operations/source-config.ts
@@ -120,12 +120,19 @@ export const ingestionRunMetadataSchema = z.object({
   metadataBytes: z.number().int().nonnegative().nullable().default(null),
   rawRowCount: z.number().int().nonnegative().default(0),
   sampleRows: z.array(z.array(z.string())).default([]),
-  truncated: z.object({
-    cellValues: z.boolean().default(false),
-    headers: z.boolean().default(false),
-    metadata: z.boolean().default(false),
-    sampleRows: z.boolean().default(false),
-  }),
+  truncated: z
+    .object({
+      cellValues: z.boolean().default(false),
+      headers: z.boolean().default(false),
+      metadata: z.boolean().default(false),
+      sampleRows: z.boolean().default(false),
+    })
+    .default({
+      cellValues: false,
+      headers: false,
+      metadata: false,
+      sampleRows: false,
+    }),
   valuesSource: z.string().trim().min(1).default("google_api"),
 });
 


### PR DESCRIPTION
## Summary
- add a default object for ingestion run metadata.truncated
- keep empty or legacy ingestion run metadata from crashing /app/admin/ingestion-runs
- unblock the final hosted Phase B proof rerun

## Validation
- npm run check
- npm run build
- APP_URL_OVERRIDE=http://127.0.0.1:3000 TMPDIR=/Users/blake/Documents/accelerate-global/accelerate-core/.tmp/playwright-tmp PLAYWRIGHT_BROWSERS_PATH=/Users/blake/Documents/accelerate-global/accelerate-core/.tmp/playwright-browsers node .tmp/browser_phaseb_probe.mjs