### PR TITLE
[codex] Merge preview into main

### DIFF
--- a/src/app/(public)/auth/callback/page.tsx
+++ b/src/app/(public)/auth/callback/page.tsx
@@ -1,11 +1,4 @@
-import { redirect } from "next/navigation";
-
 import { AuthCallbackClient } from "@/features/auth/auth-callback-client";
-import {
-  exchangeCodeForSession,
-  finalizeSessionOnboarding,
-  getCurrentUser,
-} from "@/features/auth/server";
 import { routes } from "@/lib/routes";
 
 interface AuthCallbackPageProps {
@@ -35,25 +28,10 @@ export default async function AuthCallbackPage({
   searchParams,
 }: AuthCallbackPageProps) {
   const params = await searchParams;
-  const code = readParam(params.code);
   const nextPath = getSafeNextPath(readParam(params.next, routes.appHome));
+  const authCode = readParam(params.code);
 
-  if (!code) {
-    return <AuthCallbackClient nextPath={nextPath} />;
-  }
-
-  try {
-    await exchangeCodeForSession(code);
-    const user = await getCurrentUser();
-
-    if (!user) {
-      redirect(`${routes.login}?status=error`);
-    }
-
-    await finalizeSessionOnboarding(user);
-  } catch {
-    redirect(routes.authSetupIncomplete);
-  }
-
-  redirect(nextPath);
+  return (
+    <AuthCallbackClient authCode={authCode || undefined} nextPath={nextPath} />
+  );
 }

--- a/src/features/auth/auth-callback-client.tsx
+++ b/src/features/auth/auth-callback-client.tsx
@@ -14,8 +14,20 @@ const getInternalPath = (value: string): string => {
 };
 
 interface AuthCallbackClientProps {
+  authCode?: string;
   nextPath: string;
 }
+
+const exchangeCodeForBrowserSession = async (
+  authCode: string
+): Promise<void> => {
+  const supabase = createBrowserSupabaseClient();
+  const { error } = await supabase.auth.exchangeCodeForSession(authCode);
+
+  if (error) {
+    throw error;
+  }
+};
 
 const maybeSetSessionFromHash = async (): Promise<void> => {
   const hashParams = new URLSearchParams(window.location.hash.slice(1));
@@ -57,7 +69,10 @@ const finalizeBrowserSession = async (): Promise<void> => {
   }
 };
 
-export const AuthCallbackClient = ({ nextPath }: AuthCallbackClientProps) => {
+export const AuthCallbackClient = ({
+  authCode,
+  nextPath,
+}: AuthCallbackClientProps) => {
   const router = useRouter();
 
   useEffect(() => {
@@ -65,7 +80,12 @@ export const AuthCallbackClient = ({ nextPath }: AuthCallbackClientProps) => {
 
     const run = async () => {
       try {
-        await maybeSetSessionFromHash();
+        if (authCode) {
+          await exchangeCodeForBrowserSession(authCode);
+        } else {
+          await maybeSetSessionFromHash();
+        }
+
         await ensureAuthenticatedBrowserSession();
         await finalizeBrowserSession();
 
@@ -84,7 +104,7 @@ export const AuthCallbackClient = ({ nextPath }: AuthCallbackClientProps) => {
     return () => {
       isCancelled = true;
     };
-  }, [nextPath, router]);
+  }, [authCode, nextPath, router]);
 
   return (
     <p className="rounded-lg border bg-muted/30 px-4 py-3 text-muted-foreground text-sm">

--- a/tests/admin-operations.spec.ts
+++ b/tests/admin-operations.spec.ts
@@ -585,6 +585,14 @@ const runHostedProductionProof = async ({
     runId,
     source: validationSource,
   });
+  const selectedRunDetailCard = page
+    .locator("[data-slot='card']")
+    .filter({
+      has: page.getByText("Source snapshot"),
+    })
+    .filter({
+      has: page.getByText("Run summary"),
+    });
 
   await expect(page.getByText("Run details")).toBeVisible();
   await expect(
@@ -601,7 +609,9 @@ const runHostedProductionProof = async ({
   await expect(
     page.getByText(`Range: ${runExpectations.expectedRange}`)
   ).toBeVisible();
-  await expect(page.getByText("Succeeded")).toBeVisible();
+  await expect(
+    selectedRunDetailCard.getByText("Succeeded", { exact: true })
+  ).toBeVisible();
 
   const pipelineRunId = await waitForDeferredPipelineRunId({
     ingestionRunId: runId,
@@ -614,7 +624,12 @@ const runHostedProductionProof = async ({
   await expect(
     page.getByRole("heading", { exact: true, name: "Pipeline Runs" })
   ).toBeVisible();
-  await expect(page.getByText("Deferred scaffold only")).toBeVisible();
+  await expect(
+    page.getByRole("heading", {
+      exact: true,
+      name: "Deferred scaffold only",
+    })
+  ).toBeVisible();
   await expect(
     page.getByText("Execution mode: deferred_scaffold")
   ).toBeVisible();


### PR DESCRIPTION
## Summary
- merge the latest auth callback fix and Phase B closeout changes from preview into main

## Included validation
- npm run check
- npm run build
- TMPDIR=$PWD/.tmp/playwright-tmp PLAYWRIGHT_BROWSERS_PATH=$PWD/.tmp/playwright-browsers node .tmp/auth_callback_hash_probe.mjs