### PR TITLE
Remove auth debug instrumentation

### DIFF
--- a/src/app/api/auth/finalize/route.ts
+++ b/src/app/api/auth/finalize/route.ts
@@ -1,96 +1,17 @@
-import { appendFileSync } from "node:fs";
-
 import { NextResponse } from "next/server";
 
 import { finalizeSessionOnboarding } from "@/features/auth/server";
 import { requireAuthenticatedUser } from "@/lib/auth/server";
-
-// #region agent log
-const DEBUG_LOG_PATH =
-  "/Users/blake/Documents/accelerate-global/accelerate-core/.cursor/debug-3fada2.log";
-
-const appendDebugNdjson = (payload: Record<string, unknown>): void => {
-  try {
-    appendFileSync(
-      DEBUG_LOG_PATH,
-      `${JSON.stringify({
-        sessionId: "3fada2",
-        timestamp: Date.now(),
-        ...payload,
-      })}\n`
-    );
-  } catch {
-    // Debug-only; ignore I/O errors (e.g. read-only env).
-  }
-};
-// #endregion
 
 export async function POST() {
   try {
     const user = await requireAuthenticatedUser();
     await finalizeSessionOnboarding(user);
 
-    appendDebugNdjson({
-      runId: "post-fix",
-      hypothesisId: "H6",
-      location: "api/auth/finalize/route.ts:POST:success",
-      message: "finalize server ok",
-      data: { ok: true },
-    });
-
-    // #region agent log
-    fetch("http://127.0.0.1:7415/ingest/07b71db7-16df-4bc6-97e9-ca1555981d7e", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Debug-Session-Id": "3fada2",
-      },
-      body: JSON.stringify({
-        sessionId: "3fada2",
-        runId: "post-fix",
-        hypothesisId: "H6",
-        location: "api/auth/finalize/route.ts:POST:success",
-        message: "finalize server ok",
-        data: { ok: true },
-        timestamp: Date.now(),
-      }),
-    }).catch(() => undefined);
-    // #endregion
-
     return NextResponse.json({
       ok: true,
     });
   } catch (error) {
-    const msg =
-      error instanceof Error ? error.message.slice(0, 180) : "unknown";
-
-    appendDebugNdjson({
-      runId: "post-fix",
-      hypothesisId: "H6",
-      location: "api/auth/finalize/route.ts:POST:catch",
-      message: "finalize server error",
-      data: { errorSnippet: msg },
-    });
-
-    // #region agent log
-    fetch("http://127.0.0.1:7415/ingest/07b71db7-16df-4bc6-97e9-ca1555981d7e", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Debug-Session-Id": "3fada2",
-      },
-      body: JSON.stringify({
-        sessionId: "3fada2",
-        runId: "post-fix",
-        hypothesisId: "H6",
-        location: "api/auth/finalize/route.ts:POST:catch",
-        message: "finalize server error",
-        data: { errorSnippet: msg },
-        timestamp: Date.now(),
-      }),
-    }).catch(() => undefined);
-    // #endregion
-
     return NextResponse.json(
       {
         message:

--- a/src/features/auth/auth-callback-client.tsx
+++ b/src/features/auth/auth-callback-client.tsx
@@ -101,32 +101,7 @@ const finalizeBrowserSession = async (): Promise<void> => {
         return;
       }
 
-      // #region agent log
-      const failMsg = await getFinalizeErrorMessage(finalizeResponse);
-      fetch(
-        "http://127.0.0.1:7415/ingest/07b71db7-16df-4bc6-97e9-ca1555981d7e",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Debug-Session-Id": "3fada2",
-          },
-          body: JSON.stringify({
-            sessionId: "3fada2",
-            runId: "post-fix",
-            hypothesisId: "H5",
-            location: "auth-callback-client.tsx:finalizeBrowserSession",
-            message: "finalize API not ok",
-            data: {
-              httpStatus: finalizeResponse.status,
-              messageSnippet: failMsg.slice(0, 160),
-            },
-            timestamp: Date.now(),
-          }),
-        }
-      ).catch(() => undefined);
-      lastError = new Error(failMsg);
-      // #endregion
+      lastError = new Error(await getFinalizeErrorMessage(finalizeResponse));
     } catch (error) {
       lastError =
         error instanceof Error
@@ -145,115 +120,17 @@ export const AuthCallbackClient = ({ nextPath }: AuthCallbackClientProps) => {
     let isCancelled = false;
 
     const run = async () => {
-      // #region agent log
-      const hashParams = new URLSearchParams(window.location.hash.slice(1));
-      fetch(
-        "http://127.0.0.1:7415/ingest/07b71db7-16df-4bc6-97e9-ca1555981d7e",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "X-Debug-Session-Id": "3fada2",
-          },
-          body: JSON.stringify({
-            sessionId: "3fada2",
-            runId: "post-fix",
-            hypothesisId: "H1",
-            location: "auth-callback-client.tsx:run:start",
-            message: "callback path selection",
-            data: {
-              hasHashAccessToken: hashParams.has("access_token"),
-              hasHashRefreshToken: hashParams.has("refresh_token"),
-            },
-            timestamp: Date.now(),
-          }),
-        }
-      ).catch(() => undefined);
-      // #endregion
-
       try {
         await maybeSetSessionFromHash();
 
         await ensureAuthenticatedBrowserSession();
 
-        // #region agent log
-        const supabaseAfter = createBrowserSupabaseClient();
-        const { data: userCheck } = await supabaseAfter.auth.getUser();
-        fetch(
-          "http://127.0.0.1:7415/ingest/07b71db7-16df-4bc6-97e9-ca1555981d7e",
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              "X-Debug-Session-Id": "3fada2",
-            },
-            body: JSON.stringify({
-              sessionId: "3fada2",
-              runId: "post-fix",
-              hypothesisId: "H2",
-              location: "auth-callback-client.tsx:run:after-session",
-              message: "browser session before finalize",
-              data: { hasUser: Boolean(userCheck.user) },
-              timestamp: Date.now(),
-            }),
-          }
-        ).catch(() => undefined);
-        // #endregion
-
         await finalizeBrowserSession();
-
-        // #region agent log
-        fetch(
-          "http://127.0.0.1:7415/ingest/07b71db7-16df-4bc6-97e9-ca1555981d7e",
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              "X-Debug-Session-Id": "3fada2",
-            },
-            body: JSON.stringify({
-              sessionId: "3fada2",
-              runId: "post-fix",
-              hypothesisId: "H3",
-              location: "auth-callback-client.tsx:run:finalize-ok",
-              message: "finalize completed",
-              data: { ok: true },
-              timestamp: Date.now(),
-            }),
-          }
-        ).catch(() => undefined);
-        // #endregion
 
         if (!isCancelled) {
           router.replace(getInternalPath(nextPath));
         }
-      } catch (error) {
-        // #region agent log
-        const errMsg =
-          error instanceof Error ? error.message : "non-error throw";
-        fetch(
-          "http://127.0.0.1:7415/ingest/07b71db7-16df-4bc6-97e9-ca1555981d7e",
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              "X-Debug-Session-Id": "3fada2",
-            },
-            body: JSON.stringify({
-              sessionId: "3fada2",
-              runId: "post-fix",
-              hypothesisId: "H4",
-              location: "auth-callback-client.tsx:run:catch",
-              message: "callback flow error",
-              data: {
-                errorSnippet: errMsg.slice(0, 200),
-              },
-              timestamp: Date.now(),
-            }),
-          }
-        ).catch(() => undefined);
-        // #endregion
-
+      } catch {
         if (!isCancelled) {
           router.replace("/auth/setup-incomplete");
         }


### PR DESCRIPTION
## Summary

Removes temporary debug instrumentation from the magic-link auth callback flow now that the underlying login issue is resolved.

## Changes

- `src/features/auth/auth-callback-client.tsx` — Deletes ingest `fetch` calls, folded `#region agent log` blocks, and logging-only `getUser()` checks. Keeps the production flow: hash session (if present), ensure browser session, `POST /api/auth/finalize`, then navigate to the app or `/auth/setup-incomplete` on failure.

- `src/app/api/auth/finalize/route.ts` — Deletes filesystem NDJSON append, debug `fetch` to the local ingest endpoint, and related helpers. Restores a minimal handler that finalizes onboarding and returns JSON.

## Notes

- No pull request template was found in this repository.
- This branch only contains instrumentation removal; auth behavior matches the post-fix implementation on `preview` aside from logging.