### PR TITLE
Draft: Debug instrumentation for Google Workspace connector

### DIFF
--- a/src/lib/sources/google-workspace/server.ts
+++ b/src/lib/sources/google-workspace/server.ts
@@ -462,6 +462,23 @@ const requestGoogleAccessToken = async (
       },
       method: "POST",
     });
+    // #region agent log
+    fetch("http://127.0.0.1:7415/ingest/07b71db7-16df-4bc6-97e9-ca1555981d7e", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Debug-Session-Id": "15f9c0",
+      },
+      body: JSON.stringify({
+        sessionId: "15f9c0",
+        location: "google-workspace/server.ts:requestGoogleAccessToken",
+        message: "Google OAuth token HTTP response",
+        data: { status: response.status, ok: response.ok },
+        timestamp: Date.now(),
+        hypothesisId: "A",
+      }),
+    }).catch(() => {});
+    // #endregion
   } catch (error) {
     if (error instanceof GoogleWorkspaceRequestTimeoutError) {
       throw createValidationError(
@@ -543,6 +560,23 @@ const fetchGoogleSpreadsheetMetadata = async (
 
   if (!response.ok) {
     const payload = await readJsonResponse(response);
+    // #region agent log
+    fetch("http://127.0.0.1:7415/ingest/07b71db7-16df-4bc6-97e9-ca1555981d7e", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Debug-Session-Id": "15f9c0",
+      },
+      body: JSON.stringify({
+        sessionId: "15f9c0",
+        location: "google-workspace/server.ts:fetchGoogleSpreadsheetMetadata",
+        message: "Google Sheets metadata non-OK",
+        data: { status: response.status, hasPayload: payload != null },
+        timestamp: Date.now(),
+        hypothesisId: "B",
+      }),
+    }).catch(() => {});
+    // #endregion
 
     if (response.status === 404) {
       throw createValidationError(
@@ -650,6 +684,23 @@ const fetchGoogleDriveMetadata = async (
 
   if (!response.ok) {
     const payload = await readJsonResponse(response);
+    // #region agent log
+    fetch("http://127.0.0.1:7415/ingest/07b71db7-16df-4bc6-97e9-ca1555981d7e", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Debug-Session-Id": "15f9c0",
+      },
+      body: JSON.stringify({
+        sessionId: "15f9c0",
+        location: "google-workspace/server.ts:fetchGoogleDriveMetadata",
+        message: "Google Drive metadata non-OK",
+        data: { status: response.status, hasPayload: payload != null },
+        timestamp: Date.now(),
+        hypothesisId: "D",
+      }),
+    }).catch(() => {});
+    // #endregion
 
     if (response.status === 404) {
       throw createValidationError(
@@ -963,6 +1014,23 @@ const fetchGooglePreviewValues = async ({
 
   if (!response.ok) {
     const payload = await readJsonResponse(response);
+    // #region agent log
+    fetch("http://127.0.0.1:7415/ingest/07b71db7-16df-4bc6-97e9-ca1555981d7e", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Debug-Session-Id": "15f9c0",
+      },
+      body: JSON.stringify({
+        sessionId: "15f9c0",
+        location: "google-workspace/server.ts:fetchGooglePreviewValues",
+        message: "Google Sheets preview values non-OK",
+        data: { status: response.status, hasPayload: payload != null },
+        timestamp: Date.now(),
+        hypothesisId: "E",
+      }),
+    }).catch(() => {});
+    // #endregion
 
     if (response.status === 400) {
       throw createValidationError(
@@ -1129,6 +1197,34 @@ export const getSafeGoogleWorkspaceSourceStatus =
       if (error instanceof GoogleWorkspaceOperatorError) {
         return getStatusFromOperatorError(error);
       }
+
+      // #region agent log
+      {
+        const err = error instanceof Error ? error : new Error(String(error));
+        fetch(
+          "http://127.0.0.1:7415/ingest/07b71db7-16df-4bc6-97e9-ca1555981d7e",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "X-Debug-Session-Id": "15f9c0",
+            },
+            body: JSON.stringify({
+              sessionId: "15f9c0",
+              location:
+                "google-workspace/server.ts:getSafeGoogleWorkspaceSourceStatus",
+              message: "Unexpected non-operator error",
+              data: {
+                name: err.name,
+                message: err.message.slice(0, 400),
+              },
+              timestamp: Date.now(),
+              hypothesisId: "C",
+            }),
+          }
+        ).catch(() => {});
+      }
+      // #endregion
 
       return createGoogleWorkspaceSourceStatus({
         details: [


### PR DESCRIPTION
## Summary

Adds temporary server-side instrumentation in `getSafeGoogleWorkspaceSourceStatus` and the Google Sheets/Drive request helpers to POST structured debug events (HTTP status and safe error metadata) to the local Cursor debug ingest endpoint during investigation of the Admin APIs Google Workspace connector.

## Changes

- Log OAuth token response status after the Google token endpoint call.
- Log non-OK responses for Sheets metadata, Sheets preview values, and Drive metadata requests.
- Log unexpected non-operator errors in `getSafeGoogleWorkspaceSourceStatus` (truncated message, no secrets).

## Notes

- Instrumentation is wrapped in `#region agent log` blocks for easy removal after the issue is confirmed fixed.
- This is intended for local or short-lived debugging; consider removing or gating before long-term production use.

## Testing

- [ ] Load `/app/admin/apis` as an admin locally with `GOOGLE_WORKSPACE_*` env set and confirm connector behavior; verify debug events when the ingest server is available.


Made with [Cursor](https://cursor.com)