### PR TITLE
Add file-backed NDJSON for Google Workspace debug ingest

### DIFF
--- a/src/lib/sources/google-workspace/server.ts
+++ b/src/lib/sources/google-workspace/server.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { createSign } from "node:crypto";
+import { appendFileSync } from "node:fs";
 
 import { z } from "zod";
 
@@ -26,6 +27,37 @@ const GOOGLE_WORKSPACE_SCOPES = [
 const GOOGLE_WORKSPACE_DEFAULT_DETAIL =
   "Google Workspace connector is ready for read-only validation.";
 const A1_RANGE_PATTERN = /^([A-Za-z]+)?(\d+)?(?::([A-Za-z]+)?(\d+)?)?$/;
+
+const AGENT_DEBUG_LOG_PATH =
+  "/Users/blake/Documents/accelerate-global/accelerate-core/.cursor/debug-15f9c0.log";
+
+const agentDebugIngest = (entry: {
+  location: string;
+  message: string;
+  data?: Record<string, unknown>;
+  hypothesisId: string;
+}): void => {
+  const payload = {
+    sessionId: "15f9c0",
+    timestamp: Date.now(),
+    ...entry,
+  };
+  try {
+    appendFileSync(AGENT_DEBUG_LOG_PATH, `${JSON.stringify(payload)}\n`);
+  } catch {
+    // ignore
+  }
+  fetch("http://127.0.0.1:7415/ingest/07b71db7-16df-4bc6-97e9-ca1555981d7e", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Debug-Session-Id": "15f9c0",
+    },
+    body: JSON.stringify(payload),
+  }).catch(() => {
+    /* debug ingest is best-effort */
+  });
+};
 
 const googleWorkspaceEnvSchema = z.object({
   range: z.string().trim().min(1).optional(),
@@ -463,21 +495,12 @@ const requestGoogleAccessToken = async (
       method: "POST",
     });
     // #region agent log
-    fetch("http://127.0.0.1:7415/ingest/07b71db7-16df-4bc6-97e9-ca1555981d7e", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Debug-Session-Id": "15f9c0",
-      },
-      body: JSON.stringify({
-        sessionId: "15f9c0",
-        location: "google-workspace/server.ts:requestGoogleAccessToken",
-        message: "Google OAuth token HTTP response",
-        data: { status: response.status, ok: response.ok },
-        timestamp: Date.now(),
-        hypothesisId: "A",
-      }),
-    }).catch(() => {});
+    agentDebugIngest({
+      location: "google-workspace/server.ts:requestGoogleAccessToken",
+      message: "Google OAuth token HTTP response",
+      data: { status: response.status, ok: response.ok },
+      hypothesisId: "A",
+    });
     // #endregion
   } catch (error) {
     if (error instanceof GoogleWorkspaceRequestTimeoutError) {
@@ -561,21 +584,12 @@ const fetchGoogleSpreadsheetMetadata = async (
   if (!response.ok) {
     const payload = await readJsonResponse(response);
     // #region agent log
-    fetch("http://127.0.0.1:7415/ingest/07b71db7-16df-4bc6-97e9-ca1555981d7e", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Debug-Session-Id": "15f9c0",
-      },
-      body: JSON.stringify({
-        sessionId: "15f9c0",
-        location: "google-workspace/server.ts:fetchGoogleSpreadsheetMetadata",
-        message: "Google Sheets metadata non-OK",
-        data: { status: response.status, hasPayload: payload != null },
-        timestamp: Date.now(),
-        hypothesisId: "B",
-      }),
-    }).catch(() => {});
+    agentDebugIngest({
+      location: "google-workspace/server.ts:fetchGoogleSpreadsheetMetadata",
+      message: "Google Sheets metadata non-OK",
+      data: { status: response.status, hasPayload: payload != null },
+      hypothesisId: "B",
+    });
     // #endregion
 
     if (response.status === 404) {
@@ -685,21 +699,12 @@ const fetchGoogleDriveMetadata = async (
   if (!response.ok) {
     const payload = await readJsonResponse(response);
     // #region agent log
-    fetch("http://127.0.0.1:7415/ingest/07b71db7-16df-4bc6-97e9-ca1555981d7e", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Debug-Session-Id": "15f9c0",
-      },
-      body: JSON.stringify({
-        sessionId: "15f9c0",
-        location: "google-workspace/server.ts:fetchGoogleDriveMetadata",
-        message: "Google Drive metadata non-OK",
-        data: { status: response.status, hasPayload: payload != null },
-        timestamp: Date.now(),
-        hypothesisId: "D",
-      }),
-    }).catch(() => {});
+    agentDebugIngest({
+      location: "google-workspace/server.ts:fetchGoogleDriveMetadata",
+      message: "Google Drive metadata non-OK",
+      data: { status: response.status, hasPayload: payload != null },
+      hypothesisId: "D",
+    });
     // #endregion
 
     if (response.status === 404) {
@@ -1015,21 +1020,12 @@ const fetchGooglePreviewValues = async ({
   if (!response.ok) {
     const payload = await readJsonResponse(response);
     // #region agent log
-    fetch("http://127.0.0.1:7415/ingest/07b71db7-16df-4bc6-97e9-ca1555981d7e", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Debug-Session-Id": "15f9c0",
-      },
-      body: JSON.stringify({
-        sessionId: "15f9c0",
-        location: "google-workspace/server.ts:fetchGooglePreviewValues",
-        message: "Google Sheets preview values non-OK",
-        data: { status: response.status, hasPayload: payload != null },
-        timestamp: Date.now(),
-        hypothesisId: "E",
-      }),
-    }).catch(() => {});
+    agentDebugIngest({
+      location: "google-workspace/server.ts:fetchGooglePreviewValues",
+      message: "Google Sheets preview values non-OK",
+      data: { status: response.status, hasPayload: payload != null },
+      hypothesisId: "E",
+    });
     // #endregion
 
     if (response.status === 400) {
@@ -1201,28 +1197,16 @@ export const getSafeGoogleWorkspaceSourceStatus =
       // #region agent log
       {
         const err = error instanceof Error ? error : new Error(String(error));
-        fetch(
-          "http://127.0.0.1:7415/ingest/07b71db7-16df-4bc6-97e9-ca1555981d7e",
-          {
-            method: "POST",
-            headers: {
-              "Content-Type": "application/json",
-              "X-Debug-Session-Id": "15f9c0",
-            },
-            body: JSON.stringify({
-              sessionId: "15f9c0",
-              location:
-                "google-workspace/server.ts:getSafeGoogleWorkspaceSourceStatus",
-              message: "Unexpected non-operator error",
-              data: {
-                name: err.name,
-                message: err.message.slice(0, 400),
-              },
-              timestamp: Date.now(),
-              hypothesisId: "C",
-            }),
-          }
-        ).catch(() => {});
+        agentDebugIngest({
+          location:
+            "google-workspace/server.ts:getSafeGoogleWorkspaceSourceStatus",
+          message: "Unexpected non-operator error",
+          data: {
+            name: err.name,
+            message: err.message.slice(0, 400),
+          },
+          hypothesisId: "C",
+        });
       }
       // #endregion
 


### PR DESCRIPTION
## Summary

Adds a shared `agentDebugIngest` helper in the Google Workspace server module that writes one NDJSON line per event to the Cursor debug session log file on disk, in addition to the existing HTTP ingest POST. This makes local debugging reliable when the ingest server does not mirror events into the workspace log file.

## Motivation

During investigation of the Admin APIs Google Workspace connector, ingest-only instrumentation did not produce a readable `.cursor/debug-*.log` file for analysis. Duplicating the same payload to an append-only NDJSON file removes that gap for server-side Next.js runs.

## Implementation

- Import `appendFileSync` from `node:fs`.
- Define `AGENT_DEBUG_LOG_PATH` (session `15f9c0`) and `agentDebugIngest` (append + fetch, best-effort catch).
- Replace inline ingest `fetch` blocks with `agentDebugIngest` calls for OAuth token, Sheets metadata, Sheets preview, Drive metadata, and unexpected errors in `getSafeGoogleWorkspaceSourceStatus`.

## Notes

- Instrumentation remains behind `#region agent log` folds for later removal.
- The log path is fixed for this debug session; remove or generalize when cleaning up instrumentation.

## Testing

- [ ] Run the app locally, load `/app/admin/apis` as an admin with `GOOGLE_WORKSPACE_*` configured, and confirm NDJSON lines appear in the session log file.


Made with [Cursor](https://cursor.com)