### PR TITLE
Fix Google Workspace debug log path (cwd + mkdir + flow)

### DIFF
--- a/src/lib/sources/google-workspace/server.ts
+++ b/src/lib/sources/google-workspace/server.ts
@@ -1,7 +1,8 @@
 import "server-only";
 
 import { createSign } from "node:crypto";
-import { appendFileSync } from "node:fs";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
 
 import { z } from "zod";
 
@@ -28,8 +29,7 @@ const GOOGLE_WORKSPACE_DEFAULT_DETAIL =
   "Google Workspace connector is ready for read-only validation.";
 const A1_RANGE_PATTERN = /^([A-Za-z]+)?(\d+)?(?::([A-Za-z]+)?(\d+)?)?$/;
 
-const AGENT_DEBUG_LOG_PATH =
-  "/Users/blake/Documents/accelerate-global/accelerate-core/.cursor/debug-15f9c0.log";
+const AGENT_DEBUG_LOG_PATH = join(process.cwd(), ".cursor", "debug-15f9c0.log");
 
 const agentDebugIngest = (entry: {
   location: string;
@@ -43,6 +43,7 @@ const agentDebugIngest = (entry: {
     ...entry,
   };
   try {
+    mkdirSync(dirname(AGENT_DEBUG_LOG_PATH), { recursive: true });
     appendFileSync(AGENT_DEBUG_LOG_PATH, `${JSON.stringify(payload)}\n`);
   } catch {
     // ignore
@@ -1188,6 +1189,14 @@ export const getGoogleWorkspaceSourceStatus =
 export const getSafeGoogleWorkspaceSourceStatus =
   async (): Promise<GoogleWorkspaceSourceStatus> => {
     try {
+      // #region agent log
+      agentDebugIngest({
+        location:
+          "google-workspace/server.ts:getSafeGoogleWorkspaceSourceStatus",
+        message: "Google Workspace safe status check started",
+        hypothesisId: "flow",
+      });
+      // #endregion
       return await getGoogleWorkspaceSourceStatus();
     } catch (error) {
       if (error instanceof GoogleWorkspaceOperatorError) {


### PR DESCRIPTION
## Summary

Improves the temporary Google Workspace connector debug instrumentation so NDJSON logs are reliably written when running the app from the repository root.

## Problem

The previous implementation used a hardcoded absolute log path and did not ensure the `.cursor/` directory existed. On many machines or when the directory was missing, `appendFileSync` failed and errors were swallowed, so no `debug-15f9c0.log` appeared for analysis.

## Changes

- Resolve the session log path with `join(process.cwd(), ".cursor", "debug-15f9c0.log")`.
- Call `mkdirSync(..., { recursive: true })` for the parent directory before appending.
- Emit a `flow` log at the start of `getSafeGoogleWorkspaceSourceStatus` so the first line confirms the admin page invoked the connector path.

HTTP ingest to the Cursor debug endpoint is unchanged; this is additive to local file capture.

## Testing

- [ ] `npm run dev` from repo root, load `/app/admin/apis` as admin with `GOOGLE_WORKSPACE_*` set, confirm `.cursor/debug-15f9c0.log` contains at least a `flow` entry and any failure-related hypothesis lines.


Made with [Cursor](https://cursor.com)