### PR TITLE
Anchor Google Workspace debug NDJSON path to import.meta.url

### DIFF
--- a/src/lib/sources/google-workspace/server.ts
+++ b/src/lib/sources/google-workspace/server.ts
@@ -1,8 +1,9 @@
 import "server-only";
 
 import { createSign } from "node:crypto";
-import { appendFileSync, mkdirSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { z } from "zod";
 
@@ -29,7 +30,35 @@ const GOOGLE_WORKSPACE_DEFAULT_DETAIL =
   "Google Workspace connector is ready for read-only validation.";
 const A1_RANGE_PATTERN = /^([A-Za-z]+)?(\d+)?(?::([A-Za-z]+)?(\d+)?)?$/;
 
-const AGENT_DEBUG_LOG_PATH = join(process.cwd(), ".cursor", "debug-15f9c0.log");
+const findAccelerateCoreRepoRoot = (startDir: string): string => {
+  let dir = startDir;
+  for (let i = 0; i < 24; i += 1) {
+    const pkgPath = join(dir, "package.json");
+    if (existsSync(pkgPath)) {
+      try {
+        const raw = readFileSync(pkgPath, "utf8");
+        const pkg = JSON.parse(raw) as { name?: string };
+        if (pkg.name === "core") {
+          return dir;
+        }
+      } catch {
+        // keep walking
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return startDir;
+};
+
+const AGENT_DEBUG_LOG_PATH = join(
+  findAccelerateCoreRepoRoot(dirname(fileURLToPath(import.meta.url))),
+  ".cursor",
+  "debug-15f9c0.log"
+);
 
 const agentDebugIngest = (entry: {
   location: string;
@@ -45,8 +74,11 @@ const agentDebugIngest = (entry: {
   try {
     mkdirSync(dirname(AGENT_DEBUG_LOG_PATH), { recursive: true });
     appendFileSync(AGENT_DEBUG_LOG_PATH, `${JSON.stringify(payload)}\n`);
-  } catch {
-    // ignore
+  } catch (error) {
+    if (process.env.NODE_ENV === "development") {
+      // eslint-disable-next-line no-console -- debug session: surface EACCES / path issues
+      console.error("[agent-debug] NDJSON append failed", error);
+    }
   }
   fetch("http://127.0.0.1:7415/ingest/07b71db7-16df-4bc6-97e9-ca1555981d7e", {
     method: "POST",
@@ -1194,6 +1226,11 @@ export const getSafeGoogleWorkspaceSourceStatus =
         location:
           "google-workspace/server.ts:getSafeGoogleWorkspaceSourceStatus",
         message: "Google Workspace safe status check started",
+        data: {
+          cwd: process.cwd(),
+          logPath: AGENT_DEBUG_LOG_PATH,
+          repoRootSource: "import.meta.url",
+        },
         hypothesisId: "flow",
       });
       // #endregion


### PR DESCRIPTION
## Summary

Improves temporary Google Workspace connector debug logging so NDJSON lines are written to a stable path under the **accelerate-core** repo when running `next dev`, instead of depending on `process.cwd()` (which often does not match the repo root in Next.js server code).

## Problem

Session logs were not appearing at `.cursor/debug-15f9c0.log` in the workspace because repo-root detection used `process.cwd()`. The Next server process can run with a different working directory, so `findAccelerateCoreRepoRoot(process.cwd())` could resolve incorrectly or writes could fail silently.

## Changes

- Resolve repo root by walking up from `dirname(fileURLToPath(import.meta.url))` until `package.json` has `"name": "core"`.
- Keep `AGENT_DEBUG_LOG_PATH` as `<repo>/.cursor/debug-15f9c0.log` with `mkdirSync(..., { recursive: true })` before append.
- On append failure, log `[agent-debug] NDJSON append failed` to stderr in **development** only.
- Extend the `flow` debug line with `repoRootSource: "import.meta.url"` alongside existing `cwd` / `logPath` fields.

HTTP ingest to the Cursor debug endpoint is unchanged.

## Testing

- [ ] `npm run dev` from repo root, load `/app/admin/apis` as admin with `GOOGLE_WORKSPACE_*` set; confirm `.cursor/debug-15f9c0.log` is created and contains `hypothesisId` `flow` (and any A/B/D/E/C lines).
- [ ] If the file is still missing, confirm the dev terminal shows no `NDJSON append failed` error (or capture that error for follow-up).


Made with [Cursor](https://cursor.com)